### PR TITLE
[tools] Describe more table attributes

### DIFF
--- a/src/kudu/cfile/encoding-test.cc
+++ b/src/kudu/cfile/encoding-test.cc
@@ -51,7 +51,6 @@
 #include "kudu/util/group_varint-inl.h"
 #include "kudu/util/hexdump.h"
 #include "kudu/util/int128.h"
-#include "kudu/util/int128_util.h" // IWYU pragma: keep
 #include "kudu/util/memory/arena.h"
 #include "kudu/util/random.h"
 #include "kudu/util/random_util.h"

--- a/src/kudu/client/schema.cc
+++ b/src/kudu/client/schema.cc
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include <boost/optional/optional.hpp>
+#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include "kudu/client/schema-internal.h"
@@ -38,9 +39,13 @@
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/map-util.h"
 #include "kudu/gutil/strings/substitute.h"
-#include "kudu/util/decimal_util.h"
 #include "kudu/util/compression/compression.pb.h"
+#include "kudu/util/decimal_util.h"
 #include "kudu/util/slice.h"
+
+DEFINE_bool(show_attributes, false,
+            "Whether to show column attributes, including column encoding type, "
+            "compression type, and default read/write value.");
 
 MAKE_ENUM_LIMITS(kudu::client::KuduColumnStorageAttributes::EncodingType,
                  kudu::client::KuduColumnStorageAttributes::AUTO_ENCODING,
@@ -747,7 +752,9 @@ void KuduSchema::GetPrimaryKeyColumnIndexes(vector<int>* indexes) const {
 }
 
 string KuduSchema::ToString() const {
-  return schema_ ? schema_->ToString(Schema::ToStringMode::WITHOUT_COLUMN_IDS)
+  return schema_ ? schema_->ToString(FLAGS_show_attributes ?
+                                     Schema::ToStringMode::WITH_COLUMN_ATTRIBUTES
+                                     : Schema::ToStringMode::BASE_INFO)
                  : "()";
 }
 

--- a/src/kudu/common/schema-test.cc
+++ b/src/kudu/common/schema-test.cc
@@ -118,7 +118,7 @@ TEST_F(TestSchema, TestSchemaToStringMode) {
             "    key INT32 NOT NULL,\n"
             "    PRIMARY KEY (key)\n"
             ")",
-            schema.ToString(Schema::ToStringMode::WITHOUT_COLUMN_IDS));
+            schema.ToString(Schema::ToStringMode::BASE_INFO));
 }
 
 TEST_F(TestSchema, TestCopyAndMove) {

--- a/src/kudu/common/schema.h
+++ b/src/kudu/common/schema.h
@@ -228,13 +228,25 @@ class ColumnSchema {
     return name_;
   }
 
+  // Enum to configure how a ColumnSchema is stringified.
+  enum class ToStringMode {
+    // Include encoding type, compression type, and default read/write value.
+    WITH_ATTRIBUTES,
+    // Do not include above attributes.
+    WITHOUT_ATTRIBUTES,
+  };
+
   // Return a string identifying this column, including its
   // name.
-  std::string ToString() const;
+  std::string ToString(ToStringMode mode = ToStringMode::WITHOUT_ATTRIBUTES) const;
 
   // Same as above, but only including the type information.
   // For example, "STRING NOT NULL".
   std::string TypeToString() const;
+
+  // Same as above, but only including the attributes information.
+  // For example, "AUTO_ENCODING ZLIB 123 123".
+  std::string AttrToString() const;
 
   // Returns true if the column has a read default value
   bool has_read_default() const {
@@ -724,11 +736,12 @@ class Schema {
   }
 
   // Enum to configure how a Schema is stringified.
-  enum class ToStringMode {
+  enum ToStringMode {
+    BASE_INFO = 0,
     // Include column ids if this instance has them.
-    WITH_COLUMN_IDS,
-    // Do not include column ids.
-    WITHOUT_COLUMN_IDS,
+    WITH_COLUMN_IDS = 1 << 0,
+    // Include column attributes.
+    WITH_COLUMN_ATTRIBUTES = 1 << 1,
   };
   // Stringify this Schema. This is not particularly efficient,
   // so should only be used when necessary for output.

--- a/src/kudu/common/types.h
+++ b/src/kudu/common/types.h
@@ -37,6 +37,7 @@
 #include "kudu/gutil/strings/escaping.h"
 #include "kudu/gutil/strings/numbers.h"
 #include "kudu/util/int128.h"
+#include "kudu/util/int128_util.h"
 #include "kudu/util/slice.h"
 // IWYU pragma: no_include "kudu/util/status.h"
 

--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -111,7 +111,6 @@
 #include "kudu/tserver/tserver_admin.proxy.h"
 #include "kudu/util/async_util.h"
 #include "kudu/util/env.h"
-#include "kudu/util/int128_util.h" // IWYU pragma: keep
 #include "kudu/util/metrics.h"
 #include "kudu/util/monotime.h"
 #include "kudu/util/net/net_util.h"

--- a/src/kudu/tools/tool_action_table.cc
+++ b/src/kudu/tools/tool_action_table.cc
@@ -407,6 +407,7 @@ unique_ptr<Mode> BuildTableMode() {
       .Description("Describe a table")
       .AddRequiredParameter({ kMasterAddressesArg, kMasterAddressesArgDesc })
       .AddRequiredParameter({ kTableNameArg, "Name of the table to describe" })
+      .AddOptionalParameter("show_attributes")
       .Build();
 
   unique_ptr<Action> list_tables =

--- a/src/kudu/util/int128_util.h
+++ b/src/kudu/util/int128_util.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include "kudu/util/int128.h"
 
 #include <iostream>
@@ -36,4 +38,3 @@ inline std::ostream& operator<<(std::ostream& os, const unsigned __int128& val) 
 }
 
 } // namespace std
-


### PR DESCRIPTION
This add more attributes to describe a table, including its
encoding type, compression type, and default read/write value.
My use case of the extra information is to compare two tables
in the same or different clusters: export the full descriptions
of the two tables into texts, and then use any text compare tool
to check the difference.