### PR TITLE
[metrics] Merge metrics by table

### DIFF
--- a/src/kudu/util/hdr_histogram.h
+++ b/src/kudu/util/hdr_histogram.h
@@ -170,6 +170,12 @@ class HdrHistogram {
 
   // Dump a formatted, multiline string describing this histogram to 'out'.
   void DumpHumanReadable(std::ostream* out) const;
+
+  // Merges 'other' into this HdrHistogram. Values in each 'counts_' array
+  // bucket will be added up, and the related 'min_value_', 'max_value_',
+  // 'total_count_' and 'total_sum_' will be updated if needed.
+  void MergeFrom(const HdrHistogram& other);
+
  private:
   friend class AbstractHistogramIterator;
 
@@ -179,6 +185,7 @@ class HdrHistogram {
 
   void Init();
   int CountsArrayIndex(int bucket_index, int sub_bucket_index) const;
+  void UpdateMinMax(int64_t min, int64_t max);
 
   uint64_t highest_trackable_value_;
   int num_significant_digits_;

--- a/src/kudu/util/metrics-test.cc
+++ b/src/kudu/util/metrics-test.cc
@@ -18,10 +18,13 @@
 #include "kudu/util/metrics.h"
 
 #include <cstdint>
+#include <map>
+#include <memory>
 #include <ostream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <gflags/gflags_declare.h>
@@ -31,7 +34,7 @@
 
 #include "kudu/gutil/bind.h"
 #include "kudu/gutil/bind_helpers.h"
-#include "kudu/gutil/gscoped_ptr.h"
+#include "kudu/gutil/casts.h"
 #include "kudu/gutil/map-util.h"
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/util/hdr_histogram.h"
@@ -60,12 +63,23 @@ class MetricsTest : public KuduTest {
   void SetUp() override {
     KuduTest::SetUp();
 
-    entity_ = METRIC_ENTITY_test_entity.Instantiate(&registry_, "my-test");
+    entity_ = METRIC_ENTITY_test_entity.Instantiate(&registry_, "my-test-same-attr1");
+    entity_->SetAttribute("attr_for_merge", "same_attr");
+
+    entity_same_attr_ = METRIC_ENTITY_test_entity.Instantiate(&registry_, "my-test-same-attr2");
+    entity_same_attr_->SetAttribute("attr_for_merge", "same_attr");
+
+    entity_diff_attr_ = METRIC_ENTITY_test_entity.Instantiate(&registry_, "my-test-diff-attr");
+    entity_diff_attr_->SetAttribute("attr_for_merge", "diff_attr");
   }
 
  protected:
+  const int kEntityCount = 3;
+
   MetricRegistry registry_;
   scoped_refptr<MetricEntity> entity_;
+  scoped_refptr<MetricEntity> entity_same_attr_;
+  scoped_refptr<MetricEntity> entity_diff_attr_;
 };
 
 METRIC_DEFINE_counter(test_entity, test_counter, "My Test Counter", MetricUnit::kRequests,
@@ -82,6 +96,78 @@ TEST_F(MetricsTest, SimpleCounterTest) {
   ASSERT_EQ(3, requests->value());
 }
 
+TEST_F(MetricsTest, SimpleCounterMergeTest) {
+  scoped_refptr<Counter> requests =
+    new Counter(&METRIC_test_counter);
+  scoped_refptr<Counter> requests_for_merge =
+    new Counter(&METRIC_test_counter);
+  requests->IncrementBy(2);
+  requests_for_merge->IncrementBy(3);
+  ASSERT_TRUE(requests_for_merge->MergeFrom(requests));
+  ASSERT_EQ(2, requests->value());
+  ASSERT_EQ(5, requests_for_merge->value());
+  requests->IncrementBy(7);
+  ASSERT_TRUE(requests_for_merge->MergeFrom(requests));
+  ASSERT_EQ(9, requests->value());
+  ASSERT_EQ(14, requests_for_merge->value());
+  ASSERT_TRUE(requests_for_merge->MergeFrom(requests_for_merge));
+  ASSERT_EQ(14, requests_for_merge->value());
+}
+
+METRIC_DEFINE_gauge_string(test_entity, test_string_gauge, "Test string Gauge",
+                           MetricUnit::kState, "Description of string Gauge");
+
+TEST_F(MetricsTest, SimpleStringGaugeTest) {
+  scoped_refptr<StringGauge> state =
+    new StringGauge(&METRIC_test_string_gauge, "Healthy");
+  ASSERT_EQ(METRIC_test_string_gauge.description(), state->prototype()->description());
+  ASSERT_EQ("Healthy", state->value());
+  state->set_value("Under-replicated");
+  ASSERT_EQ("Under-replicated", state->value());
+  state->set_value("Recovering");
+  ASSERT_EQ("Recovering", state->value());
+}
+
+TEST_F(MetricsTest, SimpleStringGaugeForMergeTest) {
+  scoped_refptr<StringGauge> state =
+    new StringGauge(&METRIC_test_string_gauge, "Healthy");
+  scoped_refptr<StringGauge> state_for_merge =
+    new StringGauge(&METRIC_test_string_gauge, "Recovering");
+  ASSERT_TRUE(state_for_merge->MergeFrom(state));
+  ASSERT_EQ("Healthy", state->value());
+  ASSERT_EQ(unordered_set<string>({"Recovering", "Healthy"}),
+            state_for_merge->unique_values());
+
+  scoped_refptr<StringGauge> state_old =
+      down_cast<StringGauge*>(state->snapshot().get());
+  ASSERT_EQ("Healthy", state_old->value());
+  scoped_refptr<StringGauge> state_for_merge_old =
+      down_cast<StringGauge*>(state_for_merge->snapshot().get());
+  ASSERT_EQ(unordered_set<string>({"Recovering", "Healthy"}),
+            state_for_merge_old->unique_values());
+
+  state_old->set_value("Unavailable");
+  ASSERT_EQ("Unavailable", state_old->value());
+  ASSERT_TRUE(state_for_merge_old->MergeFrom(state_old));
+  ASSERT_EQ(unordered_set<string>({"Unavailable", "Recovering", "Healthy"}),
+            state_for_merge_old->unique_values());
+
+  state->set_value("Under-replicated");
+  ASSERT_TRUE(state_for_merge->MergeFrom(state));
+  ASSERT_EQ(unordered_set<string>({"Under-replicated", "Healthy", "Recovering"}),
+            state_for_merge->unique_values());
+
+  ASSERT_TRUE(state_for_merge->MergeFrom(state_for_merge_old));
+  ASSERT_EQ(unordered_set<string>({"Unavailable", "Healthy", "Recovering"}),
+            state_for_merge_old->unique_values());
+  ASSERT_EQ(unordered_set<string>({"Unavailable", "Under-replicated", "Healthy", "Recovering"}),
+            state_for_merge->unique_values());
+
+  ASSERT_TRUE(state_for_merge->MergeFrom(state_for_merge));
+  ASSERT_EQ(unordered_set<string>({"Unavailable", "Under-replicated", "Healthy", "Recovering"}),
+            state_for_merge->unique_values());
+}
+
 METRIC_DEFINE_gauge_uint64(test_entity, test_gauge, "Test uint64 Gauge",
                            MetricUnit::kBytes, "Description of Test Gauge");
 
@@ -94,6 +180,22 @@ TEST_F(MetricsTest, SimpleAtomicGaugeTest) {
   ASSERT_EQ(7, mem_usage->value());
   mem_usage->set_value(5);
   ASSERT_EQ(5, mem_usage->value());
+}
+
+TEST_F(MetricsTest, SimpleAtomicGaugeMergeTest) {
+  scoped_refptr<AtomicGauge<uint64_t> > mem_usage =
+    METRIC_test_gauge.Instantiate(entity_, 2);
+  scoped_refptr<AtomicGauge<uint64_t> > mem_usage_for_merge =
+    METRIC_test_gauge.Instantiate(entity_same_attr_, 3);
+  ASSERT_TRUE(mem_usage_for_merge->MergeFrom(mem_usage));
+  ASSERT_EQ(2, mem_usage->value());
+  ASSERT_EQ(5, mem_usage_for_merge->value());
+  mem_usage->IncrementBy(7);
+  ASSERT_TRUE(mem_usage_for_merge->MergeFrom(mem_usage));
+  ASSERT_EQ(9, mem_usage->value());
+  ASSERT_EQ(14, mem_usage_for_merge->value());
+  ASSERT_TRUE(mem_usage_for_merge->MergeFrom(mem_usage_for_merge));
+  ASSERT_EQ(14, mem_usage_for_merge->value());
 }
 
 METRIC_DEFINE_gauge_int64(test_entity, test_func_gauge, "Test Function Gauge",
@@ -120,6 +222,78 @@ TEST_F(MetricsTest, SimpleFunctionGaugeTest) {
   // Test resetting to a constant.
   gauge->DetachToConstant(2);
   ASSERT_EQ(2, gauge->value());
+}
+
+METRIC_DEFINE_gauge_int64(test_entity, test_func_gauge_snapshot, "Test Function Gauge snapshot",
+                          MetricUnit::kOperations, "Description of Function Gauge snapshot");
+class FunctionGaugeOwner {
+ public:
+  explicit FunctionGaugeOwner(const scoped_refptr<MetricEntity>& entity) {
+    METRIC_test_func_gauge_snapshot.InstantiateFunctionGauge(entity,
+       Bind(&FunctionGaugeOwner::Count, Unretained(this)))
+       ->AutoDetach(&metric_detacher_);
+  }
+
+  int64_t Count() {
+    return count_++;
+  }
+
+ private:
+  int64_t count_ = 0;
+  FunctionGaugeDetacher metric_detacher_;
+};
+
+TEST_F(MetricsTest, SimpleFunctionGaugeSnapshotTest) {
+  std::unique_ptr<FunctionGaugeOwner> fgo(new FunctionGaugeOwner(entity_));
+  scoped_refptr<FunctionGauge<int64_t>> old_metric = down_cast<FunctionGauge<int64_t>*>(
+    entity_->FindOrNull(METRIC_test_func_gauge_snapshot).get());
+  ASSERT_EQ(0, old_metric->value());
+  ASSERT_EQ(1, old_metric->value());  // old_metric increased to 2.
+  // old_metric increased to 3, and new_metric stay at 2.
+  scoped_refptr<FunctionGauge<int64_t>> new_metric =
+      down_cast<FunctionGauge<int64_t>*>(old_metric->snapshot().get());
+  ASSERT_EQ(3, old_metric->value());
+  ASSERT_EQ(4, old_metric->value());
+  ASSERT_EQ(2, new_metric->value());
+  ASSERT_EQ(2, new_metric->value());
+}
+
+TEST_F(MetricsTest, ReleasableFunctionGaugeSnapshotTest) {
+  scoped_refptr<FunctionGauge<int64_t>> new_metric;
+  {
+    std::unique_ptr<FunctionGaugeOwner> fgo(new FunctionGaugeOwner(entity_));
+    scoped_refptr<FunctionGauge<int64_t>> old_metric = down_cast<FunctionGauge<int64_t>*>(
+      entity_->FindOrNull(METRIC_test_func_gauge_snapshot).get());
+    ASSERT_EQ(0, old_metric->value());
+    ASSERT_EQ(1, old_metric->value());  // old_metric increased to 2.
+    // old_metric increased to 3, and new_metric stay at 2.
+    new_metric = down_cast<FunctionGauge<int64_t>*>(old_metric->snapshot().get());
+  }
+  ASSERT_EQ(2, new_metric->value());
+  ASSERT_EQ(2, new_metric->value());
+}
+
+TEST_F(MetricsTest, SimpleFunctionGaugeMergeTest) {
+  int metric_val = 1000;
+  scoped_refptr<FunctionGauge<int64_t> > gauge =
+    METRIC_test_func_gauge.InstantiateFunctionGauge(
+      entity_, Bind(&MyFunction, Unretained(&metric_val)));
+
+  int metric_val_for_merge = 1234;
+  scoped_refptr<FunctionGauge<int64_t> > gauge_for_merge =
+    METRIC_test_func_gauge.InstantiateFunctionGauge(
+      entity_same_attr_, Bind(&MyFunction, Unretained(&metric_val_for_merge)));
+
+  ASSERT_TRUE(gauge_for_merge->MergeFrom(gauge));
+  ASSERT_EQ(1001, gauge->value());
+  ASSERT_EQ(1002, gauge->value());
+  ASSERT_EQ(2234, gauge_for_merge->value());
+  ASSERT_EQ(2234, gauge_for_merge->value());
+  ASSERT_TRUE(gauge_for_merge->MergeFrom(gauge));
+  ASSERT_EQ(3237, gauge_for_merge->value());
+  ASSERT_EQ(3237, gauge_for_merge->value());
+  ASSERT_TRUE(gauge_for_merge->MergeFrom(gauge_for_merge));
+  ASSERT_EQ(3237, gauge_for_merge->value());
 }
 
 TEST_F(MetricsTest, AutoDetachToLastValue) {
@@ -173,12 +347,40 @@ TEST_F(MetricsTest, SimpleHistogramTest) {
   scoped_refptr<Histogram> hist = METRIC_test_hist.Instantiate(entity_);
   hist->Increment(2);
   hist->IncrementBy(4, 1);
-  ASSERT_EQ(2, hist->histogram_->MinValue());
-  ASSERT_EQ(3, hist->histogram_->MeanValue());
-  ASSERT_EQ(4, hist->histogram_->MaxValue());
-  ASSERT_EQ(2, hist->histogram_->TotalCount());
-  ASSERT_EQ(6, hist->histogram_->TotalSum());
-  // TODO: Test coverage needs to be improved a lot.
+  ASSERT_EQ(2, hist->histogram()->MinValue());
+  ASSERT_EQ(3, hist->histogram()->MeanValue());
+  ASSERT_EQ(4, hist->histogram()->MaxValue());
+  ASSERT_EQ(2, hist->histogram()->TotalCount());
+  ASSERT_EQ(6, hist->histogram()->TotalSum());
+  // TODO(someone): Test coverage needs to be improved a lot.
+}
+
+TEST_F(MetricsTest, SimpleHistogramMergeTest) {
+  scoped_refptr<Histogram> hist = METRIC_test_hist.Instantiate(entity_);
+  scoped_refptr<Histogram> hist_for_merge = METRIC_test_hist.Instantiate(entity_same_attr_);
+  hist->Increment(2);
+  hist->IncrementBy(6, 1);
+  hist_for_merge->Increment(1);
+  hist_for_merge->IncrementBy(3, 3);
+  ASSERT_TRUE(hist_for_merge->MergeFrom(hist));
+  ASSERT_EQ(2, hist->histogram()->MinValue());
+  ASSERT_EQ(4, hist->histogram()->MeanValue());
+  ASSERT_EQ(6, hist->histogram()->MaxValue());
+  ASSERT_EQ(2, hist->histogram()->TotalCount());
+  ASSERT_EQ(8, hist->histogram()->TotalSum());
+  ASSERT_EQ(1, hist_for_merge->histogram()->MinValue());
+  ASSERT_EQ(3, hist_for_merge->histogram()->MeanValue());
+  ASSERT_EQ(6, hist_for_merge->histogram()->MaxValue());
+  ASSERT_EQ(6, hist_for_merge->histogram()->TotalCount());
+  ASSERT_EQ(18, hist_for_merge->histogram()->TotalSum());
+  ASSERT_EQ(1, hist_for_merge->histogram()->ValueAtPercentile(20.0));
+  ASSERT_EQ(2, hist_for_merge->histogram()->ValueAtPercentile(30.0));
+  ASSERT_EQ(3, hist_for_merge->histogram()->ValueAtPercentile(50.0));
+  ASSERT_EQ(3, hist_for_merge->histogram()->ValueAtPercentile(90.0));
+  ASSERT_EQ(6, hist_for_merge->histogram()->ValueAtPercentile(100.0));
+  ASSERT_TRUE(hist_for_merge->MergeFrom(hist_for_merge));
+  ASSERT_EQ(6, hist_for_merge->histogram()->TotalCount());
+  ASSERT_EQ(18, hist_for_merge->histogram()->TotalSum());
 }
 
 TEST_F(MetricsTest, JsonPrintTest) {
@@ -228,7 +430,7 @@ TEST_F(MetricsTest, JsonPrintTest) {
     out.str("");
     JsonWriter writer(&out, JsonWriter::PRETTY);
     MetricJsonOptions opts;
-    opts.entity_metrics.emplace_back("test_count");
+    opts.filters.entity_metrics.emplace_back("test_count");
     ASSERT_OK(entity_->WriteAsJson(&writer, opts));
     ASSERT_STR_CONTAINS(out.str(), METRIC_test_counter.name());
     ASSERT_STR_NOT_CONTAINS(out.str(), METRIC_test_gauge.name());
@@ -239,7 +441,7 @@ TEST_F(MetricsTest, JsonPrintTest) {
     out.str("");
     JsonWriter writer(&out, JsonWriter::PRETTY);
     MetricJsonOptions opts;
-    opts.entity_metrics.emplace_back("not_a_matching_metric");
+    opts.filters.entity_metrics.emplace_back("not_a_matching_metric");
     ASSERT_OK(entity_->WriteAsJson(&writer, opts));
     ASSERT_EQ(out.str(), "");
   }
@@ -249,10 +451,139 @@ TEST_F(MetricsTest, JsonPrintTest) {
     out.str("");
     JsonWriter writer(&out, JsonWriter::PRETTY);
     MetricJsonOptions opts;
-    opts.entity_metrics.emplace_back("teST_coUNteR");
+    opts.filters.entity_metrics.emplace_back("teST_coUNteR");
     ASSERT_OK(entity_->WriteAsJson(&writer, opts));
     ASSERT_STR_CONTAINS(out.str(), METRIC_test_counter.name());
     ASSERT_STR_NOT_CONTAINS(out.str(), METRIC_test_gauge.name());
+  }
+}
+
+// Check JSON style 'output' whether match 'expect_counters'.
+void CheckMergeOutput(const std::ostringstream& output,
+                      std::map<std::string, int> expect_counters) {
+  JsonReader reader(output.str());
+  ASSERT_OK(reader.Init());
+
+  vector<const rapidjson::Value*> counters;
+  ASSERT_OK(reader.ExtractObjectArray(reader.root(), nullptr, &counters));
+  ASSERT_EQ(expect_counters.size(), counters.size());
+  for (const auto& counter : counters) {
+    string type;
+    ASSERT_OK(reader.ExtractString(counter, "type", &type));
+    ASSERT_EQ("merged_entity", type);
+    string id;
+    ASSERT_OK(reader.ExtractString(counter, "id", &id));
+    auto it = expect_counters.find(id);
+    ASSERT_NE(it, expect_counters.end());
+    vector<const rapidjson::Value*> metrics;
+    ASSERT_OK(reader.ExtractObjectArray(counter, "metrics", &metrics));
+    string metric_name;
+    ASSERT_OK(reader.ExtractString(metrics[0], "name", &metric_name));
+    ASSERT_EQ("test_counter", metric_name);
+    int64_t metric_value;
+    ASSERT_OK(reader.ExtractInt64(metrics[0], "value", &metric_value));
+    ASSERT_EQ(it->second, metric_value);
+    expect_counters.erase(it);
+  }
+  ASSERT_TRUE(expect_counters.empty());
+}
+
+TEST_F(MetricsTest, CollectTest) {
+  scoped_refptr<Counter> test_counter = METRIC_test_counter.Instantiate(entity_);
+  test_counter->Increment();
+
+  scoped_refptr<Counter> test_counter_same_attr =
+      METRIC_test_counter.Instantiate(entity_same_attr_);
+  test_counter_same_attr->IncrementBy(10);
+
+  scoped_refptr<Counter> test_counter_diff_attr =
+      METRIC_test_counter.Instantiate(entity_diff_attr_);
+  test_counter_diff_attr->IncrementBy(100);
+
+  MetricJsonOptions base_opts;
+  base_opts.merge_rules.emplace(
+      "test_entity",
+      MergeAttributes("merged_entity", "attr_for_merge"));
+
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    ASSERT_OK(registry_.WriteAsJson(&writer, base_opts));
+    NO_FATALS(CheckMergeOutput(out, {{"same_attr", 11},
+                                     {"diff_attr", 100}}));
+  }
+
+  // Verify that metric filtering matches on substrings.
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_metrics.emplace_back("counter");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {{"same_attr", 11},
+                                     {"diff_attr", 100}}));
+  }
+
+  // Verify that, if we filter for a metric that isn't in this entity, we get no result.
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_metrics.emplace_back("not_a_matching_metric");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {}));
+  }
+
+  // Verify that metric entity id filtering matches on substrings.
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_ids.emplace_back("my-test-same-attr");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {{"same_attr", 11}}));
+  }
+
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_ids.emplace_back("my-test-same-attr2");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {{"same_attr", 10}}));
+  }
+
+  // Verify that, if we filter for a metric entity id that doesn't match any entity,
+  // we get no result.
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_ids.emplace_back("not_a_matching_metric_entity_id");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {}));
+  }
+
+  // Verify that some attribute filtering matches on substrings.
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_attrs.emplace_back("attr_for_merge");
+    opts.filters.entity_attrs.emplace_back("same_attr");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {{"same_attr", 11}}));
+  }
+
+  // Verify that, if we filter for an attribute that doesn't match any entity, we get no result.
+  {
+    std::ostringstream out;
+    JsonWriter writer(&out, JsonWriter::PRETTY);
+    MetricJsonOptions opts(base_opts);
+    opts.filters.entity_attrs.emplace_back("attr_for_merge");
+    opts.filters.entity_attrs.emplace_back("not_a_matching_attr");
+    ASSERT_OK(registry_.WriteAsJson(&writer, opts));
+    NO_FATALS(CheckMergeOutput(out, {}));
   }
 }
 
@@ -285,10 +616,12 @@ TEST_F(MetricsTest, RetirementTest) {
 }
 
 TEST_F(MetricsTest, TestRetiringEntities) {
-  ASSERT_EQ(1, registry_.num_entities());
+  ASSERT_EQ(kEntityCount, registry_.num_entities());
 
   // Drop the reference to our entity.
   entity_.reset();
+  entity_same_attr_.reset();
+  entity_diff_attr_.reset();
 
   // Retire metrics. Since there is nothing inside our entity, it should
   // retire immediately (no need to loop).
@@ -456,7 +789,7 @@ TEST_F(MetricsTest, TestFilter) {
     {
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_types = { not_exist_string };
+      opts.filters.entity_types = { not_exist_string };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       ASSERT_EQ("[]", out.str());
@@ -465,12 +798,12 @@ TEST_F(MetricsTest, TestFilter) {
       const string entity_type = "test_entity";
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_types = { entity_type };
+      opts.filters.entity_types = { entity_type };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       rapidjson::Document d;
       d.Parse<0>(out.str().c_str());
-      ASSERT_EQ(kNum + 1, d.Size());
+      ASSERT_EQ(kNum + kEntityCount, d.Size());
       ASSERT_EQ(entity_type, d[rand.Next() % kNum]["type"].GetString());
     }
   }
@@ -479,7 +812,7 @@ TEST_F(MetricsTest, TestFilter) {
     {
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_ids = { not_exist_string };
+      opts.filters.entity_ids = { not_exist_string };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       ASSERT_EQ("[]", out.str());
@@ -488,7 +821,7 @@ TEST_F(MetricsTest, TestFilter) {
       const string& entity_id = id_uuids[rand.Next() % kNum];
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_ids = { entity_id };
+      opts.filters.entity_ids = { entity_id };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       rapidjson::Document d;
@@ -502,7 +835,7 @@ TEST_F(MetricsTest, TestFilter) {
     {
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_attrs = { attr1, not_exist_string };
+      opts.filters.entity_attrs = { attr1, not_exist_string };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       ASSERT_EQ("[]", out.str());
@@ -513,7 +846,7 @@ TEST_F(MetricsTest, TestFilter) {
       const string& attr2_uuid = attr2_uuids[i];
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_attrs = { attr1, attr1_uuid };
+      opts.filters.entity_attrs = { attr1, attr1_uuid };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       rapidjson::Document d;
@@ -528,7 +861,7 @@ TEST_F(MetricsTest, TestFilter) {
     {
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_metrics = { not_exist_string };
+      opts.filters.entity_metrics = { not_exist_string };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       ASSERT_EQ("[]", out.str());
@@ -538,7 +871,7 @@ TEST_F(MetricsTest, TestFilter) {
       const string entity_metric2 = "test_gauge";
       std::ostringstream out;
       MetricJsonOptions opts;
-      opts.entity_metrics = { entity_metric1 };
+      opts.filters.entity_metrics = { entity_metric1 };
       JsonWriter w(&out, JsonWriter::PRETTY);
       ASSERT_OK(registry_.WriteAsJson(&w, opts));
       ASSERT_STR_CONTAINS(out.str(), entity_metric1);
@@ -555,7 +888,7 @@ TEST_F(MetricsTest, TestFilter) {
     ASSERT_OK(registry_.WriteAsJson(&w, MetricJsonOptions()));
     rapidjson::Document d;
     d.Parse<0>(out.str().c_str());
-    ASSERT_EQ(kNum + 1, d.Size());
+    ASSERT_EQ(kNum + kEntityCount, d.Size());
   }
 }
 

--- a/src/kudu/util/metrics.cc
+++ b/src/kudu/util/metrics.cc
@@ -24,6 +24,7 @@
 
 #include "kudu/gutil/map-util.h"
 #include "kudu/gutil/singleton.h"
+#include "kudu/gutil/strings/join.h"
 #include "kudu/gutil/strings/substitute.h"
 #include "kudu/util/flag_tags.h"
 #include "kudu/util/hdr_histogram.h"
@@ -44,8 +45,49 @@ METRIC_DEFINE_entity(server);
 namespace kudu {
 
 using std::string;
+using std::unordered_set;
 using std::vector;
 using strings::Substitute;
+
+template<typename Collection>
+void WriteMetricsToJson(JsonWriter* writer,
+                        const Collection& metrics,
+                        const MetricJsonOptions& opts) {
+  writer->String("metrics");
+  writer->StartArray();
+  for (const auto& val : metrics) {
+    const auto& m = val.second;
+    if (m->ModifiedInOrAfterEpoch(opts.only_modified_in_or_after_epoch)) {
+      if (!opts.include_untouched_metrics && m->IsUntouched()) {
+        continue;
+      }
+      WARN_NOT_OK(m->WriteAsJson(writer, opts),
+                  Substitute("Failed to write $0 as JSON", val.first->name()));
+    }
+  }
+  writer->EndArray();
+}
+
+void WriteToJson(JsonWriter* writer,
+                 const MergedEntityMetrics &merged_entity_metrics,
+                 const MetricJsonOptions &opts) {
+  for (const auto& entity_metrics : merged_entity_metrics) {
+    if (entity_metrics.second.empty()) {
+      continue;
+    }
+    writer->StartObject();
+
+    writer->String("type");
+    writer->String(entity_metrics.first.type_);
+
+    writer->String("id");
+    writer->String(entity_metrics.first.id_);
+
+    WriteMetricsToJson(writer, entity_metrics.second, opts);
+
+    writer->EndObject();
+  }
+}
 
 //
 // MetricUnit
@@ -151,7 +193,7 @@ MetricEntityPrototype::~MetricEntityPrototype() {
 
 scoped_refptr<MetricEntity> MetricEntityPrototype::Instantiate(
     MetricRegistry* registry,
-    const std::string& id,
+    const string& id,
     const MetricEntity::AttributeMap& initial_attrs) const {
   return registry->FindOrCreateEntity(this, id, initial_attrs);
 }
@@ -162,7 +204,7 @@ scoped_refptr<MetricEntity> MetricEntityPrototype::Instantiate(
 //
 
 MetricEntity::MetricEntity(const MetricEntityPrototype* prototype,
-                           std::string id, AttributeMap attributes)
+                           string id, AttributeMap attributes)
     : prototype_(prototype),
       id_(std::move(id)),
       attributes_(std::move(attributes)),
@@ -201,33 +243,37 @@ bool MatchNameInList(const string& name, const vector<string>& names) {
 
 } // anonymous namespace
 
-Status MetricEntity::WriteAsJson(JsonWriter* writer, const MetricJsonOptions& opts) const {
+Status MetricEntity::GetMetricsAndAttrs(const MetricFilters& filters,
+                                        MetricMap* metrics,
+                                        AttributeMap* attrs) const {
+  CHECK(metrics);
+  CHECK(attrs);
+
   // Filter the 'type'.
-  if (!opts.entity_types.empty() && !MatchNameInList(prototype_->name(), opts.entity_types)) {
-    return Status::OK();
-  }
-  // Filter the 'id'.
-  if (!opts.entity_ids.empty() && !MatchNameInList(id_, opts.entity_ids)) {
-    return Status::OK();
+  if (!filters.entity_types.empty() && !MatchNameInList(prototype_->name(), filters.entity_types)) {
+    return Status::NotFound("entity is filtered by entity type");
   }
 
-  MetricMap metrics;
-  AttributeMap attrs;
+  // Filter the 'id'.
+  if (!filters.entity_ids.empty() && !MatchNameInList(id_, filters.entity_ids)) {
+    return Status::NotFound("entity is filtered by entity id");
+  }
+
   {
     // Snapshot the metrics in this registry (not guaranteed to be a consistent snapshot)
     std::lock_guard<simple_spinlock> l(lock_);
-    attrs = attributes_;
-    metrics = metric_map_;
+    *attrs = attributes_;
+    *metrics = metric_map_;
   }
 
   // Filter the 'attributes'.
-  if (!opts.entity_attrs.empty()) {
+  if (!filters.entity_attrs.empty()) {
     bool match_attrs = false;
-    DCHECK(opts.entity_attrs.size() % 2 == 0);
-    for (int i = 0; i < opts.entity_attrs.size(); i += 2) {
+    DCHECK(filters.entity_attrs.size() % 2 == 0);
+    for (int i = 0; i < filters.entity_attrs.size(); i += 2) {
       // The attr_key can't be found or the attr_val can't be matched.
-      AttributeMap::const_iterator it = attrs.find(opts.entity_attrs[i]);
-      if (it == attrs.end() || !MatchNameInList(it->second, { opts.entity_attrs[i+1] })) {
+      AttributeMap::const_iterator it = attrs->find(filters.entity_attrs[i]);
+      if (it == attrs->end() || !MatchNameInList(it->second, { filters.entity_attrs[i+1] })) {
         continue;
       }
       match_attrs = true;
@@ -235,23 +281,36 @@ Status MetricEntity::WriteAsJson(JsonWriter* writer, const MetricJsonOptions& op
     }
     // None of them match.
     if (!match_attrs) {
-      return Status::OK();
+      return Status::NotFound("entity is filtered by some attribute");
     }
   }
 
   // Filter the 'metrics'.
-  if (!opts.entity_metrics.empty()) {
-    for (auto metric = metrics.begin(); metric != metrics.end();) {
-      if (!MatchNameInList(metric->first->name(), opts.entity_metrics)) {
-        metric = metrics.erase(metric);
+  if (!filters.entity_metrics.empty()) {
+    for (auto metric = metrics->begin(); metric != metrics->end();) {
+      if (!MatchNameInList(metric->first->name(), filters.entity_metrics)) {
+        metric = metrics->erase(metric);
       } else {
         ++metric;
       }
     }
     // None of them match.
-    if (metrics.empty()) {
-      return Status::OK();
+    if (metrics->empty()) {
+      return Status::NotFound("entity is filtered by metric types");
     }
+  }
+
+  return Status::OK();
+}
+
+Status MetricEntity::WriteAsJson(JsonWriter* writer, const MetricJsonOptions& opts) const {
+  MetricMap metrics;
+  AttributeMap attrs;
+  Status s = GetMetricsAndAttrs(opts.filters, &metrics, &attrs);
+  if (s.IsNotFound()) {
+    // Status::NotFound is returned when this entity has been filtered, treat it
+    // as OK, and skip printing it.
+    return Status::OK();
   }
 
   writer->StartObject();
@@ -272,21 +331,47 @@ Status MetricEntity::WriteAsJson(JsonWriter* writer, const MetricJsonOptions& op
     writer->EndObject();
   }
 
-  writer->String("metrics");
-  writer->StartArray();
-  for (MetricMap::value_type& val : metrics) {
-    const auto& m = val.second;
-    if (m->ModifiedInOrAfterEpoch(opts.only_modified_in_or_after_epoch)) {
-      if (!opts.include_untouched_metrics && m->IsUntouched()) {
-        continue;
-      }
-      WARN_NOT_OK(m->WriteAsJson(writer, opts),
-        strings::Substitute("Failed to write $0 as JSON", val.first->name()));
-    }
-  }
-  writer->EndArray();
+  WriteMetricsToJson(writer, metrics, opts);
 
   writer->EndObject();
+
+  return Status::OK();
+}
+
+Status MetricEntity::CollectTo(MergedEntityMetrics* collections,
+                               const MetricFilters& filters,
+                               const MetricMergeRules& merge_rules) const {
+  MetricMap metrics;
+  AttributeMap attrs;
+  Status s = GetMetricsAndAttrs(filters, &metrics, &attrs);
+  if (s.IsNotFound()) {
+    // Status::NotFound is returned when this entity has been filtered, treat it
+    // as OK, and skip collecting it.
+    return Status::OK();
+  }
+
+  string entity_type = prototype_->name();
+  string entity_id = id();
+  auto* merge_rule = ::FindOrNull(merge_rules, prototype_->name());
+  if (merge_rule) {
+    entity_type = merge_rule->merge_to;
+    entity_id = attrs[merge_rule->attribute_to_merge_by];
+  }
+
+  MergedEntity e(entity_type, entity_id);
+  auto& table_collection = collections->emplace(std::make_pair(e, MergedMetrics())).first->second;
+  for (const auto& val : metrics) {
+    const MetricPrototype* prototype = val.first;
+    const scoped_refptr<Metric>& metric = val.second;
+
+    scoped_refptr<Metric> entry = FindPtrOrNull(table_collection, prototype);
+    if (!entry) {
+      scoped_refptr<Metric> new_metric = metric->snapshot();
+      InsertOrDie(&table_collection, new_metric->prototype(), new_metric);
+    } else {
+      entry->MergeFrom(metric);
+    }
+  }
 
   return Status::OK();
 }
@@ -330,7 +415,6 @@ void MetricEntity::RetireOldMetrics() {
       continue;
     }
 
-
     VLOG(2) << "Retiring metric " << it->first;
     metric_map_.erase(it++);
   }
@@ -369,9 +453,18 @@ Status MetricRegistry::WriteAsJson(JsonWriter* writer, const MetricJsonOptions& 
   }
 
   writer->StartArray();
-  for (const auto& e : entities) {
-    WARN_NOT_OK(e.second->WriteAsJson(writer, opts),
-                Substitute("Failed to write entity $0 as JSON", e.second->id()));
+  if (opts.merge_rules.empty()) {
+    for (const auto& e : entities) {
+      WARN_NOT_OK(e.second->WriteAsJson(writer, opts),
+                  Substitute("Failed to write entity $0 as JSON", e.second->id()));
+    }
+  } else {
+    MergedEntityMetrics collections;
+    for (const auto& e : entities) {
+      WARN_NOT_OK(e.second->CollectTo(&collections, opts.filters, opts.merge_rules),
+                  Substitute("Failed to collect entity $0", e.second->id()));
+    }
+    WriteToJson(writer, collections, opts);
   }
   writer->EndArray();
 
@@ -502,18 +595,18 @@ FunctionGaugeDetacher::~FunctionGaugeDetacher() {
 
 scoped_refptr<MetricEntity> MetricRegistry::FindOrCreateEntity(
     const MetricEntityPrototype* prototype,
-    const std::string& id,
-    const MetricEntity::AttributeMap& initial_attributes) {
+    const string& id,
+    const MetricEntity::AttributeMap& initial_attrs) {
   std::lock_guard<simple_spinlock> l(lock_);
   scoped_refptr<MetricEntity> e = FindPtrOrNull(entities_, id);
   if (!e) {
-    e = new MetricEntity(prototype, id, initial_attributes);
+    e = new MetricEntity(prototype, id, initial_attrs);
     InsertOrDie(&entities_, id, e);
   } else if (!e->published()) {
-    e = new MetricEntity(prototype, id, initial_attributes);
+    e = new MetricEntity(prototype, id, initial_attrs);
     entities_[id] = e;
   } else {
-    e->SetAttributes(initial_attributes);
+    e->SetAttributes(initial_attrs);
   }
   return e;
 }
@@ -569,18 +662,61 @@ Status Gauge::WriteAsJson(JsonWriter* writer,
 //
 
 StringGauge::StringGauge(const GaugePrototype<string>* proto,
-                         string initial_value)
-    : Gauge(proto), value_(std::move(initial_value)) {}
+                         string initial_value,
+                         unordered_set<string> initial_unique_values)
+    : Gauge(proto),
+      value_(std::move(initial_value)),
+      unique_values_(std::move(initial_unique_values)) {}
 
-std::string StringGauge::value() const {
+scoped_refptr<Metric> StringGauge::snapshot() const {
   std::lock_guard<simple_spinlock> l(lock_);
-  return value_;
+  scoped_refptr<Metric> m
+    = new StringGauge(down_cast<const GaugePrototype<string>*>(prototype_),
+                      value_,
+                      unique_values_);
+  return m;
 }
 
-void StringGauge::set_value(const std::string& value) {
+string StringGauge::value() const {
+  std::lock_guard<simple_spinlock> l(lock_);
+  if (PREDICT_TRUE(unique_values_.empty())) {
+    return value_;
+  }
+  return JoinStrings(unique_values_, ", ");
+}
+
+void StringGauge::FillUniqueValuesUnlocked() {
+  if (unique_values_.empty()) {
+    unique_values_.insert(value_);
+  }
+}
+
+unordered_set<string> StringGauge::unique_values() {
+  std::lock_guard<simple_spinlock> l(lock_);
+  FillUniqueValuesUnlocked();
+  return unique_values_;
+}
+
+void StringGauge::set_value(const string& value) {
   UpdateModificationEpoch();
   std::lock_guard<simple_spinlock> l(lock_);
   value_ = value;
+  unique_values_.clear();
+}
+
+bool StringGauge::MergeFrom(const scoped_refptr<Metric>& other) {
+  if (PREDICT_FALSE(this == other.get())) {
+    return true;
+  }
+  UpdateModificationEpoch();
+
+  scoped_refptr<StringGauge> other_ptr = down_cast<StringGauge*>(other.get());
+  auto other_values = other_ptr->unique_values();
+
+  std::lock_guard<simple_spinlock> l(lock_);
+  FillUniqueValuesUnlocked();
+  unique_values_.insert(other_values.begin(), other_values.end());
+  return true;
 }
 
 void StringGauge::WriteValue(JsonWriter* writer) const {
@@ -655,6 +791,11 @@ scoped_refptr<Histogram> HistogramPrototype::Instantiate(
 Histogram::Histogram(const HistogramPrototype* proto)
   : Metric(proto),
     histogram_(new HdrHistogram(proto->max_trackable_value(), proto->num_sig_digits())) {
+}
+
+Histogram::Histogram(const HistogramPrototype* proto, const HdrHistogram& hdr_hist)
+  : Metric(proto),
+    histogram_(new HdrHistogram(hdr_hist)) {
 }
 
 void Histogram::Increment(int64_t value) {


### PR DESCRIPTION
This commit merge tablets metrics by table on server side, which will
reduce the total data received by any thirdparty monitor systems if they
do not care about the tablet's metrics details.

Change-Id: I8db3d082ae847eb1d83b9e4aee57d5e4bf13e1b5