### PR TITLE
[maintenance] Add extra config for maintenance manager task priority

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -44,8 +44,8 @@ only tolerate a single failure; two-master deployments cannot tolerate any failu
 
 .Operating System Requirements
 Linux::
-    - RHEL 6, RHEL 7, CentOS 6, CentOS 7, Ubuntu 14.04 (Trusty), Ubuntu 16.04 (Xenial), Debian 8
-    (Jessie), or SLES 12.
+    - RHEL 6, RHEL 7, CentOS 6, CentOS 7, Ubuntu 14.04 (trusty), Ubuntu 16.04 (xenial),
+      Ubuntu 18.04 (bionic), Debian 8 (Jessie), or SLES 12.
     - A kernel and filesystem that support _hole punching_. Hole punching is the use of the
       `fallocate(2)` system call with the `FALLOC_FL_PUNCH_HOLE` option set. See
       link:troubleshooting.html#req_hole_punching[troubleshooting hole punching] for more

--- a/java/gradle/dependencies.gradle
+++ b/java/gradle/dependencies.gradle
@@ -85,6 +85,7 @@ libs += [
     guava                : "com.google.guava:guava:$versions.guava",
     hadoopClient         : "org.apache.hadoop:hadoop-client:$versions.hadoop",
     hadoopCommon         : "org.apache.hadoop:hadoop-common:$versions.hadoop",
+    hadoopMiniCluster    : "org.apache.hadoop:hadoop-minicluster:$versions.hadoop",
     hadoopMRClientCommon : "org.apache.hadoop:hadoop-mapreduce-client-common:$versions.hadoop",
     hadoopMRClientCore   : "org.apache.hadoop:hadoop-mapreduce-client-core:$versions.hadoop",
     hamcrest             : "org.hamcrest:hamcrest:$versions.hamcrest",

--- a/java/gradle/shadow.gradle
+++ b/java/gradle/shadow.gradle
@@ -76,27 +76,9 @@ configurations.create("compileUnshaded")
 configurations.shadow.extendsFrom(configurations.compileUnshaded)
 configurations.compile.extendsFrom(configurations.compileUnshaded)
 
-// Define an overridable property to indicate tool jars that should
-// include all of their dependencies.
-// We use this below to ensure slf4j is included.
-shadow.ext {
-  isToolJar = false
-}
-
 // We use afterEvaluate to add additional configuration once all the definitions
 // in the projects build script have been applied
 afterEvaluate {
-  if (!shadow.isToolJar) {
-    shadowJar {
-      dependencies {
-        // Our shaded library jars always try to pull in the slf4j api from
-        // kudu-client, though we never want it included. Excluding it
-        // here prevents the need to always list it.
-        exclude dependency(libs.slf4jApi)
-      }
-    }
-  }
-  
   // Ensure compileUnshaded dependencies are included in the pom.
   [install, uploadArchives].each { task ->
     task.repositories.each {

--- a/java/kudu-backup-common/build.gradle
+++ b/java/kudu-backup-common/build.gradle
@@ -25,9 +25,10 @@ dependencies {
     // Make sure wrong Guava version is not pulled in.
     exclude group: "com.google.guava", module: "guava"
   }
-  compile libs.hadoopCommon
-  compile libs.scalaLibrary
   compile libs.slf4jApi
+
+  provided libs.hadoopCommon
+  provided libs.scalaLibrary
 
   optional libs.yetusAnnotations
 

--- a/java/kudu-backup-tools/build.gradle
+++ b/java/kudu-backup-tools/build.gradle
@@ -18,37 +18,22 @@
 apply plugin: "scala"
 apply from: "$rootDir/gradle/shadow.gradle"
 
-// Mark this as a tool jar so shadow doesn't exclude any dependencies when shading.
-shadow {
-  isToolJar = true
-}
-
-
-// Add the main class to the manifest so the jar can be run via `java -jar`
-jar {
-  manifest {
-    attributes 'Main-Class': 'org.apache.kudu.backup.KuduBackupCLI'
-  }
-}
-
 dependencies {
   compile project(path: ":kudu-backup-common")
   compile project(path: ":kudu-client", configuration: "shadow")
-  compile libs.hadoopCommon
   compile (libs.scopt)  {
     // Make sure wrong Scala version is not pulled in.
     exclude group: "org.scala-lang", module: "scala-library"
   }
   compile libs.scalaLibrary
-
-  // Include the logging implementation given this is a standalone command line tool.
   compile libs.slf4jApi
-  compile libs.log4j
-  compile libs.log4jSlf4jImpl
+
+  provided libs.hadoopClient
 
   optional libs.yetusAnnotations
 
   testCompile project(path: ":kudu-test-utils", configuration: "shadow")
+  testCompile libs.hadoopMiniCluster
   testCompile libs.junit
   testCompile libs.scalatest
 }

--- a/java/kudu-backup-tools/src/main/scala/org/apache/kudu/backup/KuduBackupLister.scala
+++ b/java/kudu-backup-tools/src/main/scala/org/apache/kudu/backup/KuduBackupLister.scala
@@ -34,7 +34,7 @@ object KuduBackupLister {
   // Run the backup CLI tool with the given options. Like a command, returns 0 if successful, or
   // a nonzero error code.
   def run(options: BackupCLIOptions): Int = {
-    Preconditions.checkArgument(options.mode == Mode.LIST);
+    Preconditions.checkArgument(options.mode == Mode.LIST)
 
     // Sort by table name for a consistent ordering (at least if there's no duplicate names).
     val sortedTables = options.tables.sorted

--- a/java/kudu-client/src/main/java/org/apache/kudu/client/SplitKeyRangeRequest.java
+++ b/java/kudu-client/src/main/java/org/apache/kudu/client/SplitKeyRangeRequest.java
@@ -26,6 +26,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.jboss.netty.util.Timer;
 
 import org.apache.kudu.Common.KeyRangePB;
+import org.apache.kudu.security.Token;
 import org.apache.kudu.tserver.Tserver;
 import org.apache.kudu.util.Pair;
 
@@ -39,6 +40,9 @@ class SplitKeyRangeRequest extends KuduRpc<SplitKeyRangeResponse> {
   private final byte[] endPrimaryKey;
   private final byte[] partitionKey;
   private final long splitSizeBytes;
+
+  /** The token with which to authorize this RPC. */
+  private Token.SignedTokenPB authzToken;
 
   /**
    * Create a new RPC request
@@ -81,8 +85,21 @@ class SplitKeyRangeRequest extends KuduRpc<SplitKeyRangeResponse> {
       builder.setStopPrimaryKey(UnsafeByteOperations.unsafeWrap(endPrimaryKey));
     }
     builder.setTargetChunkSizeBytes(splitSizeBytes);
+    if (authzToken != null) {
+      builder.setAuthzToken(authzToken);
+    }
 
     return builder.build();
+  }
+
+  @Override
+  boolean needsAuthzToken() {
+    return true;
+  }
+
+  @Override
+  void bindAuthzToken(Token.SignedTokenPB token) {
+    authzToken = token;
   }
 
   @Override

--- a/java/kudu-client/src/main/java/org/apache/kudu/util/SchemaGenerator.java
+++ b/java/kudu-client/src/main/java/org/apache/kudu/util/SchemaGenerator.java
@@ -235,11 +235,11 @@ public class SchemaGenerator {
     final List<ColumnSchema> keyColumns = schema.getPrimaryKeyColumns();
 
     // Add hash partitioning (Max out at 3 levels to avoid being excessive).
-    int hashPartitionLevels = random.nextInt(Math.min(keyColumns.size(), 3)) + 1;
+    int hashPartitionLevels = random.nextInt(Math.min(keyColumns.size(), 2)) + 1;
     for (int i = 0; i < hashPartitionLevels; i++) {
       final ColumnSchema hashColumn = keyColumns.get(i);
       // TODO(ghenke): Make buckets configurable.
-      final int hashBuckets = random.nextInt(8) + MIN_HASH_BUCKETS;
+      final int hashBuckets = random.nextInt(2) + MIN_HASH_BUCKETS;
       final int hashSeed = random.nextInt();
       options.addHashPartitions(Arrays.asList(hashColumn.getName()), hashBuckets, hashSeed);
     }

--- a/src/kudu/common/common.proto
+++ b/src/kudu/common/common.proto
@@ -445,4 +445,8 @@ message TableExtraConfigPB {
   // backups. Reads initiated at a snapshot that is older than this
   // age will be rejected. Equivalent to --tablet_history_max_age_sec.
   optional int32 history_max_age_sec = 1;
+
+  // Priority of a table for maintenance, valid priority level is ranged
+  // in [-FLAGS_max_priority_range, FLAGS_max_priority_range].
+  optional int32 maintenance_priority = 2;
 }

--- a/src/kudu/common/wire_protocol.cc
+++ b/src/kudu/common/wire_protocol.cc
@@ -663,7 +663,7 @@ Status ExtraConfigPBToMap(const TableExtraConfigPB& pb, map<string, string>* con
   return Status::OK();
 }
 
-Status ParseIntConfig(const std::string &name, const std::string &value, int32_t *result) {
+Status ParseIntConfig(const std::string& name, const std::string& value, int32_t* result) {
   CHECK(result);
   if (!safe_strto32(value, result)) {
     return Status::InvalidArgument(Substitute("Unable to parse $0", name), value);

--- a/src/kudu/common/wire_protocol.cc
+++ b/src/kudu/common/wire_protocol.cc
@@ -663,6 +663,14 @@ Status ExtraConfigPBToMap(const TableExtraConfigPB& pb, map<string, string>* con
   return Status::OK();
 }
 
+Status ParseIntConfig(const std::string &name, const std::string &value, int32_t *result) {
+  CHECK(result);
+  if (!safe_strto32(value, result)) {
+    return Status::InvalidArgument(Substitute("Unable to parse $0", name), value);
+  }
+  return Status::OK();
+}
+
 Status ExtraConfigPBFromPBMap(const Map<string, string>& configs, TableExtraConfigPB* pb) {
   TableExtraConfigPB result;
   for (const auto& config : configs) {
@@ -671,17 +679,13 @@ Status ExtraConfigPBFromPBMap(const Map<string, string>& configs, TableExtraConf
     if (name == kTableHistoryMaxAgeSec) {
       if (!value.empty()) {
         int32_t history_max_age_sec;
-        if (!safe_strto32(value, &history_max_age_sec)) {
-          return Status::InvalidArgument(Substitute("Unable to parse $0", name), value);
-        }
+        RETURN_NOT_OK(ParseIntConfig(name, value, &history_max_age_sec));
         result.set_history_max_age_sec(history_max_age_sec);
       }
     } else if (name == kTableMaintenancePriority) {
       if (!value.empty()) {
         int32_t maintenance_priority;
-        if (!safe_strto32(value, &maintenance_priority)) {
-          return Status::InvalidArgument(Substitute("Unable to parse $0", name), value);
-        }
+        RETURN_NOT_OK(ParseIntConfig(name, value, &maintenance_priority));
         result.set_maintenance_priority(maintenance_priority);
       }
     } else {

--- a/src/kudu/common/wire_protocol.cc
+++ b/src/kudu/common/wire_protocol.cc
@@ -654,6 +654,7 @@ Status ColumnPredicateFromPB(const Schema& schema,
 }
 
 const char kTableHistoryMaxAgeSec[] = "kudu.table.history_max_age_sec";
+const char kTableMaintenancePriority[] = "kudu.table.maintenance_priority";
 Status ExtraConfigPBToMap(const TableExtraConfigPB& pb, map<string, string>* configs) {
   Map<string, string> tmp;
   RETURN_NOT_OK(ExtraConfigPBToPBMap(pb, &tmp));
@@ -675,6 +676,14 @@ Status ExtraConfigPBFromPBMap(const Map<string, string>& configs, TableExtraConf
         }
         result.set_history_max_age_sec(history_max_age_sec);
       }
+    } else if (name == kTableMaintenancePriority) {
+      if (!value.empty()) {
+        int32_t maintenance_priority;
+        if (!safe_strto32(value, &maintenance_priority)) {
+          return Status::InvalidArgument(Substitute("Unable to parse $0", name), value);
+        }
+        result.set_maintenance_priority(maintenance_priority);
+      }
     } else {
       LOG(WARNING) << "Unknown extra configuration property: " << name;
     }
@@ -687,6 +696,9 @@ Status ExtraConfigPBToPBMap(const TableExtraConfigPB& pb, Map<string, string>* c
   Map<string, string> result;
   if (pb.has_history_max_age_sec()) {
     result[kTableHistoryMaxAgeSec] = std::to_string(pb.history_max_age_sec());
+  }
+  if (pb.has_maintenance_priority()) {
+    result[kTableMaintenancePriority] = std::to_string(pb.maintenance_priority());
   }
   *configs = std::move(result);
   return Status::OK();

--- a/src/kudu/common/wire_protocol.h
+++ b/src/kudu/common/wire_protocol.h
@@ -150,8 +150,8 @@ Status ExtraConfigPBToMap(const TableExtraConfigPB& pb,
 Status ExtraConfigPBFromPBMap(const google::protobuf::Map<std::string, std::string>& configs,
                               TableExtraConfigPB* pb);
 
-// Parse
-Status ParseIntConfig(const std::string &name, const std::string &value, int32_t* result);
+// Parse int type value from 'value', and store in 'result' when succeed.
+Status ParseIntConfig(const std::string& name, const std::string& value, int32_t* result);
 
 // Convert a extra configuration properties protobuf to protobuf::map.
 Status ExtraConfigPBToPBMap(const TableExtraConfigPB& pb,

--- a/src/kudu/common/wire_protocol.h
+++ b/src/kudu/common/wire_protocol.h
@@ -150,6 +150,9 @@ Status ExtraConfigPBToMap(const TableExtraConfigPB& pb,
 Status ExtraConfigPBFromPBMap(const google::protobuf::Map<std::string, std::string>& configs,
                               TableExtraConfigPB* pb);
 
+// Parse
+Status ParseIntConfig(const std::string &name, const std::string &value, int32_t* result);
+
 // Convert a extra configuration properties protobuf to protobuf::map.
 Status ExtraConfigPBToPBMap(const TableExtraConfigPB& pb,
                             google::protobuf::Map<std::string, std::string>* configs);

--- a/src/kudu/gutil/port.h
+++ b/src/kudu/gutil/port.h
@@ -1192,10 +1192,9 @@ using enable_if_numeric = std::enable_if<
 //   int32_t x = UnalignedLoad<int32_t>(void_ptr);
 //
 template<typename T,
-         typename port_internal::enable_if_numeric<T>::type* = nullptr,
-         bool USE_REINTERPRET = port_internal::LoadByReinterpretCast<T>()>
+         typename port_internal::enable_if_numeric<T>::type* = nullptr>
 inline T UnalignedLoad(const void* src) {
-  if (USE_REINTERPRET) {
+  if (port_internal::LoadByReinterpretCast<T>()) {
     return *reinterpret_cast<const T*>(src);
   }
   T ret;
@@ -1213,10 +1212,9 @@ inline T UnalignedLoad(const void* src) {
 // NOTE: this reverses the usual style-guide-suggested order of arguments
 // to match the more natural "*p = v;" ordering of a normal store.
 template<typename T,
-         typename port_internal::enable_if_numeric<T>::type* = nullptr,
-         bool USE_REINTERPRET = port_internal::LoadByReinterpretCast<T>()>
+         typename port_internal::enable_if_numeric<T>::type* = nullptr>
 inline void UnalignedStore(void* dst, const T& src) {
-  if (USE_REINTERPRET) {
+  if (port_internal::LoadByReinterpretCast<T>()) {
     *reinterpret_cast<T*>(dst) = src;
   } else {
     memcpy(dst, &src, sizeof(T));

--- a/src/kudu/rpc/client_negotiation.cc
+++ b/src/kudu/rpc/client_negotiation.cc
@@ -481,7 +481,9 @@ Status ClientNegotiation::HandleTlsHandshake(const NegotiatePB& response) {
     return Status::NotAuthorized("expected TLS_HANDSHAKE step",
                                  NegotiatePB::NegotiateStep_Name(response.step()));
   }
-  TRACE("Received TLS_HANDSHAKE response from server");
+  if (!response.tls_handshake().empty()) {
+    TRACE("Received TLS_HANDSHAKE response from server");
+  }
 
   if (PREDICT_FALSE(!response.has_tls_handshake())) {
     return Status::NotAuthorized("No TLS handshake token in TLS_HANDSHAKE response from server");

--- a/src/kudu/security/tls_context.cc
+++ b/src/kudu/security/tls_context.cc
@@ -61,6 +61,9 @@
 #ifndef SSL_OP_NO_TLSv1_1
 #define SSL_OP_NO_TLSv1_1 0x10000000U
 #endif
+#ifndef SSL_OP_NO_TLSv1_3
+#define SSL_OP_NO_TLSv1_3 0x20000000U
+#endif
 #ifndef TLS1_1_VERSION
 #define TLS1_1_VERSION 0x0302
 #endif
@@ -164,6 +167,10 @@ Status TlsContext::Init() {
     return Status::InvalidArgument("unknown value provided for --rpc_tls_min_protocol flag",
                                    tls_min_protocol_);
   }
+
+  // We don't currently support TLS 1.3 because the one-and-a-half-RTT negotiation
+  // confuses our RPC negotiation protocol. See KUDU-2871.
+  options |= SSL_OP_NO_TLSv1_3;
 
   SSL_CTX_set_options(ctx_.get(), options);
 

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -585,9 +585,12 @@ void ServerBase::LogUnauthorizedAccess(rpc::RpcContext* rpc) const {
                << " from " << rpc->requestor_string();
 }
 
+bool ServerBase::IsFromSuperUser(const rpc::RpcContext* rpc) {
+  return superuser_acl_.UserAllowed(rpc->remote_user().username());
+}
+
 bool ServerBase::Authorize(rpc::RpcContext* rpc, uint32_t allowed_roles) {
-  if ((allowed_roles & SUPER_USER) &&
-      superuser_acl_.UserAllowed(rpc->remote_user().username())) {
+  if ((allowed_roles & SUPER_USER) && IsFromSuperUser(rpc)) {
     return true;
   }
 

--- a/src/kudu/server/server_base.h
+++ b/src/kudu/server/server_base.h
@@ -119,6 +119,9 @@ class ServerBase {
     SERVICE_USER = 1 << 2
   };
 
+  // Returns whether or not the rpc is from a super-user.
+  bool IsFromSuperUser(const rpc::RpcContext* rpc);
+
   // Authorize an RPC. 'allowed_roles' is a bitset of which roles from the above
   // enum should be allowed to make hthe RPC.
   //

--- a/src/kudu/tablet/delta_store.h
+++ b/src/kudu/tablet/delta_store.h
@@ -493,10 +493,10 @@ class DeltaPreparer : public PreparedDeltas {
 
   // A row whose last relevant mutation was DELETE (or REINSERT).
   //
-  // These deques are disjoint; a row that was both deleted and reinserted will
+  // These lists are disjoint; a row that was both deleted and reinserted will
   // not be in either.
-  std::deque<rowid_t> deleted_;
-  std::deque<rowid_t> reinserted_;
+  std::vector<rowid_t> deleted_;
+  std::vector<rowid_t> reinserted_;
 
   // The deletion state of the row last processed by AddDelta().
   //
@@ -515,7 +515,7 @@ class DeltaPreparer : public PreparedDeltas {
     DeltaKey key;
     Slice val;
   };
-  std::deque<PreparedDelta> prepared_deltas_;
+  std::vector<PreparedDelta> prepared_deltas_;
 
   // State when prepared_for_ & PREPARED_FOR_SELECT
   // ------------------------------------------------------------

--- a/src/kudu/tablet/tablet.h
+++ b/src/kudu/tablet/tablet.h
@@ -420,7 +420,6 @@ class Tablet {
   // This method is thread-safe.
   void CancelMaintenanceOps();
 
-  const std::string& table_id() const { return metadata_->table_id(); }
   const std::string& tablet_id() const { return metadata_->tablet_id(); }
 
   // Return the metrics for this tablet.

--- a/src/kudu/tablet/tablet_mm_ops.cc
+++ b/src/kudu/tablet/tablet_mm_ops.cc
@@ -21,13 +21,16 @@
 #include <ostream>
 #include <utility>
 
+#include <boost/optional/optional.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "kudu/common/common.pb.h"
 #include "kudu/gutil/port.h"
 #include "kudu/gutil/strings/substitute.h"
 #include "kudu/tablet/rowset.h"
 #include "kudu/tablet/tablet.h"
+#include "kudu/tablet/tablet_metadata.h"
 #include "kudu/tablet/tablet_metrics.h"
 #include "kudu/util/flag_tags.h"
 #include "kudu/util/logging.h"
@@ -88,8 +91,13 @@ string TabletOpBase::LogPrefix() const {
   return tablet_->LogPrefix();
 }
 
-const std::string& TabletOpBase::table_id() const {
-  return tablet_->table_id();
+int32_t TabletOpBase::priority() const {
+  int32_t priority = 0;
+  if (tablet_->metadata()->extra_config() &&
+      tablet_->metadata()->extra_config()->has_maintenance_priority()) {
+    priority = tablet_->metadata()->extra_config()->maintenance_priority();
+  }
+  return priority;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/kudu/tablet/tablet_mm_ops.h
+++ b/src/kudu/tablet/tablet_mm_ops.h
@@ -42,7 +42,7 @@ class TabletOpBase : public MaintenanceOp {
   std::string LogPrefix() const;
 
  protected:
-  const std::string& table_id() const override;
+  int32_t priority() const override;
 
   Tablet* const tablet_;
 };

--- a/src/kudu/tablet/tablet_replica.h
+++ b/src/kudu/tablet/tablet_replica.h
@@ -256,7 +256,6 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
     return log_anchor_registry_;
   }
 
-  const std::string& table_id() const { return meta_->table_id(); }
   const std::string& tablet_id() const { return meta_->tablet_id(); }
 
   // Convenience method to return the permanent_uuid of this peer.

--- a/src/kudu/tablet/tablet_replica_mm_ops.cc
+++ b/src/kudu/tablet/tablet_replica_mm_ops.cc
@@ -23,12 +23,15 @@
 #include <string>
 #include <utility>
 
+#include <boost/optional/optional.hpp>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include "kudu/common/common.pb.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/gutil/port.h"
 #include "kudu/gutil/strings/substitute.h"
+#include "kudu/tablet/tablet_metadata.h"
 #include "kudu/tablet/tablet_metrics.h"
 #include "kudu/util/flag_tags.h"
 #include "kudu/util/logging.h"
@@ -133,8 +136,13 @@ TabletReplicaOpBase::TabletReplicaOpBase(std::string name,
       tablet_replica_(tablet_replica) {
 }
 
-const std::string& TabletReplicaOpBase::table_id() const {
-  return tablet_replica_->table_id();
+int32_t TabletReplicaOpBase::priority() const {
+  int32_t priority = 0;
+  if (tablet_replica_->tablet_metadata()->extra_config() &&
+      tablet_replica_->tablet_metadata()->extra_config()->has_maintenance_priority()) {
+    priority = tablet_replica_->tablet_metadata()->extra_config()->maintenance_priority();
+  }
+  return priority;
 }
 
 //

--- a/src/kudu/tablet/tablet_replica_mm_ops.h
+++ b/src/kudu/tablet/tablet_replica_mm_ops.h
@@ -51,7 +51,7 @@ class TabletReplicaOpBase : public MaintenanceOp {
   explicit TabletReplicaOpBase(std::string name, IOUsage io_usage, TabletReplica* tablet_replica);
 
  protected:
-  const std::string& table_id() const override;
+  int32_t priority() const override;
 
   TabletReplica *const tablet_replica_;
 };

--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -1107,6 +1107,8 @@ TEST_F(ToolTest, TestModeHelp) {
         "list.*List tables",
         "scan.*Scan rows from a table",
         "copy.*Copy table data to another table",
+        "set_extra_config.*Change a extra configuration value on a table",
+        "get_extra_configs.*Get the extra configuration properties for a table"
     };
     NO_FATALS(RunTestHelp("table", kTableModeRegexes));
   }

--- a/src/kudu/tserver/tablet_copy_client-test.cc
+++ b/src/kudu/tserver/tablet_copy_client-test.cc
@@ -146,7 +146,7 @@ class TabletCopyClientTest : public TabletCopyTest {
   Status CompareFileContents(const string& path1, const string& path2);
 
   // Injection of 'supports_live_row_count' modifiers through polymorphic characteristic.
-  virtual void GenerateTestData() {
+  void GenerateTestData() override {
     Random rand(SeedRandom());
     NO_FATALS(tablet_replica_->tablet_metadata()->
         set_supports_live_row_count_for_tests(rand.Next() % 2));

--- a/src/kudu/tserver/tablet_service.cc
+++ b/src/kudu/tserver/tablet_service.cc
@@ -1933,7 +1933,12 @@ void TabletServiceImpl::Checksum(const ChecksumRequestPB* req,
   ScanResultChecksummer collector;
   bool has_more = false;
   TabletServerErrorPB::Code error_code = TabletServerErrorPB::UNKNOWN_ERROR;
-  if (FLAGS_tserver_enforce_access_control && req->has_new_request()) {
+  // TODO(KUDU-2870): the CLI tool doesn't currently fetch authz tokens when
+  // checksumming. Until it does, allow the super-user to avoid fine-grained
+  // privilege checking.
+  if (FLAGS_tserver_enforce_access_control &&
+      !server_->IsFromSuperUser(context) &&
+      req->has_new_request()) {
     const NewScanRequestPB& new_req = req->new_request();
     TokenPB token;
     if (!VerifyAuthzTokenOrRespond(server_->token_verifier(), req->new_request(),

--- a/src/kudu/util/maintenance_manager.h
+++ b/src/kudu/util/maintenance_manager.h
@@ -230,7 +230,7 @@ class MaintenanceOp {
   }
 
  protected:
-  virtual const std::string& table_id() const = 0;
+  virtual int32_t priority() const = 0;
 
  private:
   DISALLOW_COPY_AND_ASSIGN(MaintenanceOp);
@@ -309,7 +309,6 @@ class MaintenanceManager : public std::enable_shared_from_this<MaintenanceManage
 
   typedef std::map<MaintenanceOp*, MaintenanceOpStats,
           MaintenanceOpComparator> OpMapTy;
-  typedef std::unordered_map<std::string, int32_t> TablePriorities;
 
   // Return true if tests have currently disabled the maintenance
   // manager by way of changing the gflags at runtime.
@@ -325,8 +324,7 @@ class MaintenanceManager : public std::enable_shared_from_this<MaintenanceManage
   // suitable for logging.
   std::pair<MaintenanceOp*, std::string> FindBestOp();
 
-  double PerfImprovement(double perf_improvement,
-                         const std::string& table_id) const;
+  double PerfImprovement(double perf_improvement, int32_t priority) const;
 
   void LaunchOp(MaintenanceOp* op);
 
@@ -336,13 +334,10 @@ class MaintenanceManager : public std::enable_shared_from_this<MaintenanceManage
 
   bool CouldNotLaunchNewOp(bool prev_iter_found_no_work);
 
-  void UpdateTablePriorities();
-
   void IncreaseOpCount(MaintenanceOp *op);
   void DecreaseOpCount(MaintenanceOp *op);
 
   const std::string server_uuid_;
-  TablePriorities table_priorities_;
   const int32_t num_threads_;
   OpMapTy ops_; // Registered operations.
   Mutex lock_;

--- a/thirdparty/build-if-necessary.sh
+++ b/thirdparty/build-if-necessary.sh
@@ -85,7 +85,10 @@ else
   for GROUP in $DEPENDENCY_GROUPS; do
     STAMP_FILE=.build-stamp.$GROUP
     if [ -f $STAMP_FILE ]; then
-      CHANGED_FILE_COUNT=$(find . -cnewer $STAMP_FILE | wc -l)
+      CHANGED_FILE_COUNT=$(find . -cnewer $STAMP_FILE |
+        grep -v '^\./\.build-stamp' |
+        grep -v '^\.$' |
+        wc -l)
       echo "$CHANGED_FILE_COUNT file(s) been modified since thirdparty dependency group '$GROUP' was last built."
       if [ $CHANGED_FILE_COUNT -gt 0 ]; then
         echo "Rebuilding."


### PR DESCRIPTION
While set and update priorities for multiply tables by GFlags is a
compromise, now we can improve it by extra config of tables.

Change-Id: I966ee626ef85ce56ba4517b9e494f3ac5b044867