### PR TITLE
[docs] Fix an outdated slow DNS log description

### DIFF
--- a/docs/troubleshooting.adoc
+++ b/docs/troubleshooting.adoc
@@ -663,7 +663,7 @@ For better scalability on nodes hosting many replicas, we recommend that you use
 When DNS lookups are slow, you will see a log message similar to the following:
 
 ----
-W0926 11:19:01.339553 27231 net_util.cc:129] Time spent resolving address for kudu-tserver.example.com: real 4.647s    user 0.000s     sys 0.000s
+W0926 11:19:01.339553 27231 net_util.cc:193] Time spent resolve address for kudu-tserver.example.com: real 4.647s    user 0.000s     sys 0.000s
 ----
 
 `nscd` (name service cache daemon) can alleviate slow name resolution by providing

--- a/src/kudu/scripts/kudu-log-parser.pl
+++ b/src/kudu/scripts/kudu-log-parser.pl
@@ -81,7 +81,7 @@ my $pat_blocked_reactor = qr{$pat_glog_prefix RPC callback for RPC call (\S+) ->
 # W0926 11:17:05.677790 15105 kernel_stack_watchdog.cc:146] Thread 15122 stuck at /home/mpercy/src/kudu/src/kudu/rpc/outbound_call.cc:218 for 166ms:
 my $pat_kernel_stack_watchdog = qr{$pat_glog_prefix Thread (\d+) stuck at .*/([^/]+\.\w+):(\d+) for (\S+):$};
 
-# W0926 11:19:01.339553 27231 net_util.cc:129] Time spent resolving address for foo1.example.com: real 0.202s    user 0.000s     sys 0.000s
+# W0926 11:19:01.339553 27231 net_util.cc:193] Time spent resolve address for foo1.example.com: real 0.202s    user 0.000s     sys 0.000s
 my $pat_slow_execution = qr{$pat_glog_prefix .*(Time spent .*): real (\S+)};
 
 # Global datetime formatter object.


### PR DESCRIPTION
Slow DNS log format has been changed by commit
a3773b42c41d3208dcc8fb26f4d9ff106e3e8cfe, since Kudu 1.5.0.
We have to update docs about it, then users can search it correctly when
troubleshooting.

Change-Id: Idbf34eae87399130e59ea9f9083d12efffca32ae