### PR TITLE
[metrics] Add a metric to count merged entities when merge metrics

### DIFF
--- a/src/kudu/master/catalog_manager.cc
+++ b/src/kudu/master/catalog_manager.cc
@@ -5504,6 +5504,7 @@ void TableInfo::RegisterMetrics(MetricRegistry* metric_registry, const string& t
     attrs["table_name"] = table_name;
     metric_entity_ = METRIC_ENTITY_table.Instantiate(metric_registry, table_id_, attrs);
     metrics_.reset(new TableMetrics(metric_entity_));
+    METRIC_merged_entities_count_of_table.InstantiateHidden(metric_entity_, 1);
   }
 }
 

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -218,6 +218,8 @@ DECLARE_int32(dns_resolver_max_threads_num);
 DECLARE_uint32(dns_resolver_cache_capacity_mb);
 DECLARE_uint32(dns_resolver_cache_ttl_sec);
 
+METRIC_DECLARE_gauge_size(merged_entities_count_of_server);
+
 using kudu::security::RpcAuthentication;
 using kudu::security::RpcEncryption;
 using std::ostringstream;
@@ -372,6 +374,8 @@ ServerBase::ServerBase(string name, const ServerBaseOptions& options,
           MonoDelta::FromSeconds(FLAGS_dns_resolver_cache_ttl_sec))),
       options_(options),
       stop_background_threads_latch_(1) {
+  METRIC_merged_entities_count_of_server.InstantiateHidden(metric_entity_, 1);
+
   FsManagerOpts fs_opts;
   fs_opts.metric_entity = metric_entity_;
   fs_opts.parent_mem_tracker = mem_tracker_;

--- a/src/kudu/tablet/tablet.cc
+++ b/src/kudu/tablet/tablet.cc
@@ -231,6 +231,7 @@ Tablet::Tablet(scoped_refptr<TabletMetadata> metadata,
     METRIC_num_rowsets_on_disk.InstantiateFunctionGauge(
       metric_entity_, Bind(&Tablet::num_rowsets, Unretained(this)))
       ->AutoDetach(&metric_detacher_);
+    METRIC_merged_entities_count_of_tablet.InstantiateHidden(metric_entity_, 1);
   }
 
   if (FLAGS_tablet_throttler_rpc_per_sec > 0 || FLAGS_tablet_throttler_bytes_per_sec > 0) {

--- a/src/kudu/util/metrics.h
+++ b/src/kudu/util/metrics.h
@@ -223,11 +223,10 @@
 //
 /////////////////////////////////////////////////////
 
-#include <cstring>
-
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <mutex>
 #include <string>
@@ -254,12 +253,21 @@
 #include "kudu/util/status.h"
 #include "kudu/util/striped64.h"
 
+// IWYU pragma: no_forward_declare kudu::MetricPrototype
+// IWYU pragma: no_forward_declare kudu::MetricPrototype::CtorArgs
+// IWYU pragma: no_forward_declare kudu::MetricUnit
+
 // Define a new entity type.
 //
 // The metrics subsystem itself defines the entity type 'server', but other
 // entity types can be registered using this macro.
-#define METRIC_DEFINE_entity(name)                               \
-  ::kudu::MetricEntityPrototype METRIC_ENTITY_##name(#name)
+#define METRIC_DEFINE_entity(name)                                                  \
+  ::kudu::MetricEntityPrototype METRIC_ENTITY_##name(#name);                        \
+  METRIC_DEFINE_gauge_size(name, merged_entities_count_of_##name,                   \
+                           "Entities Count Merged From",                            \
+                           kudu::MetricUnit::kEntries,                              \
+                           "Count of entities merged together when entities are "   \
+                           "merged by common attribute value.");
 
 // Convenience macros to define metric prototypes.
 // See the documentation at the top of this file for example usage.
@@ -761,6 +769,11 @@ class Metric : public RefCountedThreadSafe<Metric> {
     }
   }
 
+  // Invalidate 'm_epoch_', causing this metric to be invisible until its value changes.
+  void InvalidateEpoch() {
+    m_epoch_ = -1;
+  }
+
   // The last metrics epoch in which this metric was modified.
   // We use epochs instead of timestamps since we can ensure that epochs
   // only change rarely. Thus this member is read-mostly and doesn't cause
@@ -773,6 +786,9 @@ class Metric : public RefCountedThreadSafe<Metric> {
 
   friend class MetricEntity;
   friend class RefCountedThreadSafe<Metric>;
+  template<typename T>
+  friend class GaugePrototype;
+  FRIEND_TEST(MetricsTest, TestDumpOnlyChanged);
 
   // The time at which we should retire this metric if it is still un-referenced outside
   // of the metrics subsystem. If this metric is not due for retirement, this member is
@@ -889,6 +905,16 @@ class GaugePrototype : public MetricPrototype {
       const scoped_refptr<MetricEntity>& entity,
       const Callback<T()>& function) const {
     return entity->FindOrCreateFunctionGauge(this, function);
+  }
+
+  // Instantiate a "manual" gauge and hide it. It will appear
+  // when its value is updated, or when its entity is merged.
+  scoped_refptr<AtomicGauge<T> > InstantiateHidden(
+      const scoped_refptr<MetricEntity>& entity,
+      const T& initial_value) const {
+    auto gauge = Instantiate(entity, initial_value);
+    gauge->InvalidateEpoch();
+    return gauge;
   }
 
   virtual MetricType::Type type() const OVERRIDE {


### PR DESCRIPTION
When metric entities merged to a new entity, we don't know how many
entities it merged from.
This patch add a new metric 'merged_<entity>_entities_count' to entity
and set value to 1, then the new merged entity will have the same
metric with value merged.
We can use this information to check whether a table is balanced or
not by thirdparty monitor system efficiently. Though we can use CLI
tool like 'kudu cluster rebalance' to check per-table balance status
of a cluster, but we have to fetch balance info table by table (by add
--tables=xx flag), and also we have to "run command" in thirdparty
monitor system and this tool seems not fast enough because it will
call functions like RetrieveAllTablets.

Change-Id: I652b457a2df73414f95f5d1d5efaa003cc262bd1