### PR TITLE
[tools] Set extra-configs by JSON string

### DIFF
--- a/src/kudu/tools/kudu-admin-test.cc
+++ b/src/kudu/tools/kudu-admin-test.cc
@@ -2276,11 +2276,10 @@ TEST_F(AdminCliTest, TestExtraConfig) {
   {
     ASSERT_TOOL_OK(
       "table",
-      "set_extra_config",
+      "set_extra_configs",
       master_address,
       kTableId,
-      "kudu.table.history_max_age_sec",
-      "3600"
+      R"*({"kudu.table.history_max_age_sec":"3600","kudu.table.maintenance_priority":"-1"})*"
     );
   }
 
@@ -2294,7 +2293,8 @@ TEST_F(AdminCliTest, TestExtraConfig) {
       kTableId,
     }, &stdout, &stderr);
     ASSERT_TRUE(s.ok()) << ToolRunInfo(s, stdout, stderr);
-    ASSERT_STR_CONTAINS(stdout, "kudu.table.history_max_age_sec | 3600");
+    ASSERT_STR_MATCHES(stdout, "kudu.table.history_max_age_sec[ ]+|[ ]+3600[ ]+");
+    ASSERT_STR_MATCHES(stdout, "kudu.table.maintenance_priority[ ]+|[ ]+-1[ ]+");
   }
 
   // Gets the specified extra-config, the configuration exists.

--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -1108,7 +1108,7 @@ TEST_F(ToolTest, TestModeHelp) {
         "list.*List tables",
         "scan.*Scan rows from a table",
         "copy.*Copy table data to another table",
-        "set_extra_config.*Change a extra configuration value on a table",
+        "set_extra_configs.*Change extra configuration values on a table",
         "get_extra_configs.*Get the extra configuration properties for a table"
     };
     NO_FATALS(RunTestHelp("table", kTableModeRegexes));

--- a/src/kudu/util/jsonreader.h
+++ b/src/kudu/util/jsonreader.h
@@ -18,6 +18,7 @@
 #define KUDU_UTIL_JSONREADER_H_
 
 #include <cstdint>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -89,6 +90,11 @@ class JsonReader {
   Status ExtractObjectArray(const rapidjson::Value* object,
                             const char* field,
                             std::vector<const rapidjson::Value*>* result) const;
+
+  // 'result' is only valid for as long as JsonReader is alive.
+  Status ExtractObjectDict(const rapidjson::Value* object,
+                           const char* field,
+                           std::map<std::string, const rapidjson::Value*>* result) const;
 
   const rapidjson::Value* root() const { return &document_; }
 


### PR DESCRIPTION
When attempt to set a extra config to a negative number, the minus
will be parsed by gflags first, and then report an error, even if
it is wrapped by quotations marks.
e.g.
$ kudu table set_extra_config @onebox test_table kudu.table.maintenance_priority -1
ERROR: unknown command line flag '1'
This patch fixes this bug by passing a JSON string, and also support to
set multiple extra-configs. e.g.
$ kudu table set_extra_configs @onebox test_table '{"kudu.table.history_max_age_sec":"3600","kudu.table.maintenance_priority":"-1"}'

Change-Id: I3cc9a4c54d43bb0e0c67f42a2055b24b6f5f3f01