### PR TITLE
[metrics] Hide metric live_row_count when tablet not support

### DIFF
--- a/src/kudu/integration-tests/ts_tablet_manager-itest.cc
+++ b/src/kudu/integration-tests/ts_tablet_manager-itest.cc
@@ -755,6 +755,7 @@ TEST_F(TsTabletManagerITest, TestTableStats) {
     NO_FATALS(GetLeaderMasterAndRun(live_row_count, [&] (
       TableInfo* table_info, int64_t live_row_count) {
         ASSERT_EVENTUALLY([&] () {
+          ASSERT_TRUE(table_info->GetMetrics()->TableSupportsLiveRowCount());
           ASSERT_EQ(live_row_count, table_info->GetMetrics()->live_row_count->value());
         });
       }));
@@ -838,6 +839,7 @@ TEST_F(TsTabletManagerITest, TestTableStats) {
         ASSERT_STR_NOT_CONTAINS(metric_attrs_str, kTableName);
         ASSERT_STR_CONTAINS(metric_attrs_str, kNewTableName);
         ASSERT_EQ(table->id(), table_info->metric_entity_->id());
+        ASSERT_TRUE(table_info->GetMetrics()->TableSupportsLiveRowCount());
         ASSERT_EQ(live_row_count, table_info->GetMetrics()->live_row_count->value());
       }));
   }

--- a/src/kudu/master/catalog_manager.h
+++ b/src/kudu/master/catalog_manager.h
@@ -322,9 +322,14 @@ class TableInfo : public RefCountedThreadSafe<TableInfo> {
   // Unregister metrics for the table.
   void UnregisterMetrics();
 
-  // Update the metrics.
-  void UpdateMetrics(const tablet::ReportedTabletStatsPB& old_stats,
+  // Update stats belonging to 'tablet_id' in the table's metrics.
+  void UpdateMetrics(const std::string& tablet_id,
+                     const tablet::ReportedTabletStatsPB& old_stats,
                      const tablet::ReportedTabletStatsPB& new_stats);
+
+  // Remove stats belonging to 'tablet_id' from table metrics.
+  void RemoveMetrics(const std::string& tablet_id,
+                     const tablet::ReportedTabletStatsPB& old_stats);
 
   // Update the attributes of the metrics.
   void UpdateMetricsAttrs(const std::string& new_table_name);

--- a/src/kudu/master/master_path_handlers.cc
+++ b/src/kudu/master/master_path_handlers.cc
@@ -42,7 +42,6 @@
 #include "kudu/common/wire_protocol.pb.h"
 #include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/quorum_util.h"
-#include "kudu/gutil/integral_types.h"
 #include "kudu/gutil/map-util.h"
 #include "kudu/gutil/ref_counted.h"
 #include "kudu/gutil/stringprintf.h"
@@ -494,9 +493,8 @@ void MasterPathHandlers::HandleTablePage(const Webserver::WebRequest& req,
     // But the value of disk size will never be negative.
     (*output)["table_disk_size"] =
         HumanReadableNumBytes::ToString(table_metrics->on_disk_size->value());
-    int64 live_row_count = table_metrics->live_row_count->value();
-    if (live_row_count >= 0) {
-      (*output)["table_live_row_count"] = live_row_count;
+    if (table_metrics->TableSupportsLiveRowCount()) {
+      (*output)["table_live_row_count"] = table_metrics->live_row_count->value();
     } else {
       (*output)["table_live_row_count"] = "N/A";
     }

--- a/src/kudu/tablet/compaction-test.cc
+++ b/src/kudu/tablet/compaction-test.cc
@@ -1195,7 +1195,7 @@ TEST_F(TestCompaction, TestCountLiveRowsOfMemRowSetFlush) {
   NO_FATALS(UpdateRows(mrs.get(), 80, 0, 1));
   NO_FATALS(DeleteRows(mrs.get(), 50));
   NO_FATALS(InsertRows(mrs.get(), 10, 0));
-  int64_t count = 0;
+  uint64_t count = 0;
   ASSERT_OK(mrs->CountLiveRows(&count));
   ASSERT_EQ(100 - 50 + 10, count);
 
@@ -1250,7 +1250,7 @@ TEST_F(TestCompaction, TestCountLiveRowsOfDiskRowSetsCompact) {
   std::random_shuffle(all_rss.begin(), all_rss.end());
   NO_FATALS(CompactAndReopenNoRoll(all_rss, schema_, &result));
 
-  int64_t count = 0;
+  uint64_t count = 0;
   ASSERT_OK(result->CountLiveRows(&count));
   ASSERT_EQ((100 - 50 + 10) * 3, count);
 }

--- a/src/kudu/tablet/diskrowset.cc
+++ b/src/kudu/tablet/diskrowset.cc
@@ -756,9 +756,9 @@ Status DiskRowSet::CountRows(const IOContext* io_context, rowid_t *count) const 
   return Status::OK();
 }
 
-Status DiskRowSet::CountLiveRows(int64_t* count) const {
+Status DiskRowSet::CountLiveRows(uint64_t* count) const {
+  DCHECK_GE(rowset_metadata_->live_row_count(), delta_tracker_->CountDeletedRows());
   *count = rowset_metadata_->live_row_count() - delta_tracker_->CountDeletedRows();
-  DCHECK_GE(*count, 0);
   return Status::OK();
 }
 

--- a/src/kudu/tablet/diskrowset.h
+++ b/src/kudu/tablet/diskrowset.h
@@ -370,7 +370,7 @@ class DiskRowSet : public RowSet {
   Status CountRows(const fs::IOContext* io_context, rowid_t *count) const final override;
 
   // Count the number of live rows in this DRS.
-  virtual Status CountLiveRows(int64_t* count) const override;
+  virtual Status CountLiveRows(uint64_t* count) const override;
 
   // See RowSet::GetBounds(...)
   virtual Status GetBounds(std::string* min_encoded_key,

--- a/src/kudu/tablet/memrowset-test.cc
+++ b/src/kudu/tablet/memrowset-test.cc
@@ -823,7 +823,7 @@ TEST_F(TestMemRowSet, TestCountLiveRows) {
                               MemTracker::GetRootTracker(), &mrs));
 
   const auto CheckLiveRowsCount = [&](int64_t expect) {
-    int64_t count = 0;
+    uint64_t count = 0;
     ASSERT_OK(mrs->CountLiveRows(&count));
     ASSERT_EQ(expect, count);
   };

--- a/src/kudu/tablet/memrowset.h
+++ b/src/kudu/tablet/memrowset.h
@@ -255,9 +255,8 @@ class MemRowSet : public RowSet,
     return Status::OK();
   }
 
-  virtual Status CountLiveRows(int64_t* count) const override {
+  virtual Status CountLiveRows(uint64_t* count) const override {
     *count = live_row_count_.Load();
-    DCHECK_GE(*count, 0);
     return Status::OK();
   }
 
@@ -459,7 +458,7 @@ class MemRowSet : public RowSet,
   std::atomic<bool> has_been_compacted_;
 
   // Number of live rows in this MRS.
-  AtomicInt<int64_t> live_row_count_;
+  AtomicInt<uint64_t> live_row_count_;
 
   DISALLOW_COPY_AND_ASSIGN(MemRowSet);
 };

--- a/src/kudu/tablet/metadata.proto
+++ b/src/kudu/tablet/metadata.proto
@@ -196,6 +196,6 @@ enum TabletStatePB {
 
 // Statistics for a tablet replica.
 message ReportedTabletStatsPB {
-  required int64 on_disk_size = 1;
-  required int64 live_row_count = 2;
+  optional uint64 on_disk_size = 1;
+  optional uint64 live_row_count = 2;
 }

--- a/src/kudu/tablet/mock-rowsets.h
+++ b/src/kudu/tablet/mock-rowsets.h
@@ -70,7 +70,7 @@ class MockRowSet : public RowSet {
     LOG(FATAL) << "Unimplemented";
     return Status::OK();
   }
-  virtual Status CountLiveRows(int64_t* /*count*/) const OVERRIDE {
+  virtual Status CountLiveRows(uint64_t* /*count*/) const OVERRIDE {
     LOG(FATAL) << "Unimplemented";
     return Status::OK();
   }

--- a/src/kudu/tablet/mt-tablet-test.cc
+++ b/src/kudu/tablet/mt-tablet-test.cc
@@ -415,7 +415,7 @@ class MultiThreadedTabletTest : public TabletTestBase<SETUP> {
     while (running_insert_count_.count() > 0) {
       num_rowsets_ts->SetValue(tablet()->num_rowsets());
       memrowset_size_ts->SetValue(tablet()->MemRowSetSize() / 1024.0);
-      int64_t num_live_rows;
+      uint64_t num_live_rows;
       ignore_result(tablet()->CountLiveRows(&num_live_rows));
       num_live_rows_ts->SetValue(num_live_rows);
 

--- a/src/kudu/tablet/rowset.cc
+++ b/src/kudu/tablet/rowset.cc
@@ -230,9 +230,9 @@ Status DuplicatingRowSet::CountRows(const IOContext* io_context, rowid_t *count)
   return Status::OK();
 }
 
-Status DuplicatingRowSet::CountLiveRows(int64_t* count) const {
+Status DuplicatingRowSet::CountLiveRows(uint64_t* count) const {
   for (const shared_ptr<RowSet>& rs : old_rowsets_) {
-    int64_t tmp = 0;
+    uint64_t tmp = 0;
     RETURN_NOT_OK(rs->CountLiveRows(&tmp));
     *count += tmp;
   }

--- a/src/kudu/tablet/rowset.h
+++ b/src/kudu/tablet/rowset.h
@@ -164,7 +164,7 @@ class RowSet {
   virtual Status CountRows(const fs::IOContext* io_context, rowid_t *count) const = 0;
 
   // Count the number of live rows in this rowset.
-  virtual Status CountLiveRows(int64_t* count) const = 0;
+  virtual Status CountLiveRows(uint64_t* count) const = 0;
 
   // Return the bounds for this RowSet. 'min_encoded_key' and 'max_encoded_key'
   // are set to the first and last encoded keys for this RowSet.
@@ -409,7 +409,7 @@ class DuplicatingRowSet : public RowSet {
 
   Status CountRows(const fs::IOContext* io_context, rowid_t *count) const OVERRIDE;
 
-  virtual Status CountLiveRows(int64_t* count) const OVERRIDE;
+  virtual Status CountLiveRows(uint64_t* count) const OVERRIDE;
 
   virtual Status GetBounds(std::string* min_encoded_key,
                            std::string* max_encoded_key) const OVERRIDE;

--- a/src/kudu/tablet/tablet-test.cc
+++ b/src/kudu/tablet/tablet-test.cc
@@ -100,7 +100,7 @@ public:
   }
 
   void CheckLiveRowsCount(int64_t expect) {
-    int64_t count = 0;
+    uint64_t count = 0;
     ASSERT_OK(this->tablet()->CountLiveRows(&count));
     ASSERT_EQ(expect, count);
   }
@@ -915,7 +915,7 @@ TYPED_TEST(TestTablet, TestCountLiveRowsAfterShutdown) {
   NO_FATALS(this->tablet()->Shutdown());
 
   // Call the CountLiveRows().
-  int64_t count = 0;
+  uint64_t count = 0;
   ASSERT_TRUE(tablet->CountLiveRows(&count).IsRuntimeError());
 }
 

--- a/src/kudu/tablet/tablet.cc
+++ b/src/kudu/tablet/tablet.cc
@@ -1881,7 +1881,7 @@ Status Tablet::CountRows(uint64_t *count) const {
   return Status::OK();
 }
 
-Status Tablet::CountLiveRows(int64_t* count) const {
+Status Tablet::CountLiveRows(uint64_t* count) const {
   if (!metadata_->supports_live_row_count()) {
     return Status::NotSupported("This tablet doesn't support live row counting");
   }
@@ -1892,8 +1892,8 @@ Status Tablet::CountLiveRows(int64_t* count) const {
     return Status::RuntimeError("The tablet has been shut down");
   }
 
-  int64_t ret = 0;
-  int64_t tmp = 0;
+  uint64_t ret = 0;
+  uint64_t tmp = 0;
   RETURN_NOT_OK(comps->memrowset->CountLiveRows(&ret));
   for (const shared_ptr<RowSet>& rowset : comps->rowsets->all_rowsets()) {
     RETURN_NOT_OK(rowset->CountLiveRows(&tmp));

--- a/src/kudu/tablet/tablet.h
+++ b/src/kudu/tablet/tablet.h
@@ -348,7 +348,7 @@ class Tablet {
   Status CountRows(uint64_t *count) const;
 
   // Count the number of live rows in this tablet.
-  Status CountLiveRows(int64_t* count) const;
+  Status CountLiveRows(uint64_t* count) const;
 
   // Verbosely dump this entire tablet to the logs. This is only
   // really useful when debugging unit tests failures where the tablet

--- a/src/kudu/tablet/tablet_replica-test.cc
+++ b/src/kudu/tablet/tablet_replica-test.cc
@@ -84,7 +84,7 @@ DECLARE_int32(flush_threshold_mb);
 
 METRIC_DECLARE_entity(tablet);
 
-METRIC_DECLARE_gauge_int64(live_row_count);
+METRIC_DECLARE_gauge_uint64(live_row_count);
 
 using kudu::consensus::CommitMsg;
 using kudu::consensus::ConsensusBootstrapInfo;
@@ -780,7 +780,7 @@ TEST_F(TabletReplicaTest, TestLiveRowCountMetric) {
   ASSERT_OK(StartReplicaAndWaitUntilLeader(info));
 
   auto live_row_count = METRIC_live_row_count.InstantiateFunctionGauge(
-      tablet_replica_->tablet()->GetMetricEntity(), Callback<int64_t(void)>());
+      tablet_replica_->tablet()->GetMetricEntity(), Callback<uint64_t(void)>());
   ASSERT_EQ(0, live_row_count->value());
 
   // Insert some rows.

--- a/src/kudu/tablet/tablet_replica.h
+++ b/src/kudu/tablet/tablet_replica.h
@@ -300,9 +300,13 @@ class TabletReplica : public RefCountedThreadSafe<TabletReplica>,
   // Return the total on-disk size of this tablet replica, in bytes.
   size_t OnDiskSize() const;
 
-  // Return the number of live rows of this tablet replica.
-  // -1 will be returned if the tablet doesn't support live row counting.
-  int64_t CountLiveRows() const;
+  // Counts the number of live rows in this tablet replica.
+  //
+  // Returns a bad Status on failure.
+  Status CountLiveRows(uint64_t* live_row_count) const;
+
+  // Like CountLiveRows but returns 0 on failure.
+  uint64_t CountLiveRowsNoFail() const;
 
   // Update the tablet stats.
   // When the replica's stats change and it's the LEADER, it is added to

--- a/src/kudu/tserver/ts_tablet_manager.cc
+++ b/src/kudu/tserver/ts_tablet_manager.cc
@@ -1333,7 +1333,7 @@ void TSTabletManager::CreateReportedTabletPB(const scoped_refptr<TabletReplica>&
     // If we're the leader, report stats.
     if (cstate.leader_uuid() == fs_manager_->uuid()) {
       ReportedTabletStatsPB stats_pb = replica->GetTabletStats();
-      if (stats_pb.IsInitialized()) {
+      if (stats_pb.has_on_disk_size() || stats_pb.has_live_row_count()) {
         *reported_tablet->mutable_stats() = std::move(stats_pb);
       }
     }

--- a/src/kudu/tserver/tserver_path_handlers.cc
+++ b/src/kudu/tserver/tserver_path_handlers.cc
@@ -411,8 +411,9 @@ void TabletServerPathHandlers::HandleTabletPage(const Webserver::WebRequest& req
   output->Set("partition",
               tmeta->partition_schema().PartitionDebugString(tmeta->partition(), schema));
   output->Set("on_disk_size", HumanReadableNumBytes::ToString(replica->OnDiskSize()));
-  int64_t live_row_count = replica->CountLiveRows();
-  if (live_row_count >= 0) {
+  uint64_t live_row_count;
+  Status s = replica->CountLiveRows(&live_row_count);
+  if (s.ok()) {
     output->Set("tablet_live_row_count", live_row_count);
   } else {
     output->Set("tablet_live_row_count", "N/A");


### PR DESCRIPTION
When upgrade an tserver from version older than 1.11, and add some
partitions for an existing table, then the table will hold some tablets
that support live row counting together with some ones that not support.
Tablet which not support live row counting has value of -1, in this
case, metrics merge on tserver and metrics aggregate on master have
problems.
This patch add feature to validate metric when happend to see an invalid
metric when MergeFrom, and disable 'live_row_count' metric of a table
when any tablet of a table not support live rows counting on master.

Change-Id: I2a54704d8cbd64a521e65aa3e95bf1a68f7757b7