### PR TITLE
[metrics] Fix bugs when metrics do merge

### DIFF
--- a/src/kudu/master/catalog_manager.cc
+++ b/src/kudu/master/catalog_manager.cc
@@ -5582,7 +5582,6 @@ void TableInfo::RegisterMetrics(MetricRegistry* metric_registry, const string& t
     attrs["table_name"] = table_name;
     metric_entity_ = METRIC_ENTITY_table.Instantiate(metric_registry, table_id_, attrs);
     metrics_.reset(new TableMetrics(metric_entity_));
-    METRIC_merged_entities_count_of_table.InstantiateHidden(metric_entity_, 1);
   }
 }
 

--- a/src/kudu/master/table_metrics.cc
+++ b/src/kudu/master/table_metrics.cc
@@ -20,6 +20,8 @@
 
 #include "kudu/gutil/map-util.h"
 
+METRIC_DECLARE_gauge_size(merged_entities_count_of_table);
+
 namespace kudu {
 namespace master {
 
@@ -36,12 +38,14 @@ METRIC_DEFINE_gauge_uint64(table, live_row_count, "Table Live Row count",
     kudu::MetricLevel::kInfo);
 
 #define GINIT(x) x(METRIC_##x.Instantiate(entity, 0))
-
+#define HIDEINIT(x, v) x(METRIC_##x.InstantiateHidden(entity, v))
 TableMetrics::TableMetrics(const scoped_refptr<MetricEntity>& entity)
   : GINIT(on_disk_size),
-    GINIT(live_row_count) {
+    GINIT(live_row_count),
+    HIDEINIT(merged_entities_count_of_table, 1) {
 }
 #undef GINIT
+#undef HIDEINIT
 
 void TableMetrics::AddTabletNoLiveRowCount(const std::string& tablet_id) {
   std::lock_guard<simple_spinlock> l(lock_);

--- a/src/kudu/master/table_metrics.h
+++ b/src/kudu/master/table_metrics.h
@@ -47,6 +47,7 @@ struct TableMetrics {
 
   scoped_refptr<AtomicGauge<uint64_t>> on_disk_size;
   scoped_refptr<AtomicGauge<uint64_t>> live_row_count;
+  scoped_refptr<AtomicGauge<uint64_t>> merged_entities_count_of_table;
 
   void AddTabletNoLiveRowCount(const std::string& tablet_id);
   void DeleteTabletNoLiveRowCount(const std::string& tablet_id);

--- a/src/kudu/server/server_base.cc
+++ b/src/kudu/server/server_base.cc
@@ -372,7 +372,8 @@ ServerBase::ServerBase(string name, const ServerBaseOptions& options,
           MonoDelta::FromSeconds(FLAGS_dns_resolver_cache_ttl_sec))),
       options_(options),
       stop_background_threads_latch_(1) {
-  METRIC_merged_entities_count_of_server.InstantiateHidden(metric_entity_, 1);
+  metric_entity_->NeverRetire(
+      METRIC_merged_entities_count_of_server.InstantiateHidden(metric_entity_, 1));
 
   FsManagerOpts fs_opts;
   fs_opts.metric_entity = metric_entity_;

--- a/src/kudu/tablet/tablet.cc
+++ b/src/kudu/tablet/tablet.cc
@@ -255,7 +255,6 @@ Tablet::Tablet(scoped_refptr<TabletMetadata> metadata,
     METRIC_last_write_elapsed_time.InstantiateFunctionGauge(
       metric_entity_, Bind(&Tablet::LastWriteElapsedSeconds, Unretained(this)), MergeType::kMin)
       ->AutoDetach(&metric_detacher_);
-    METRIC_merged_entities_count_of_tablet.InstantiateHidden(metric_entity_, 1);
   }
 
   if (FLAGS_tablet_throttler_rpc_per_sec > 0 || FLAGS_tablet_throttler_bytes_per_sec > 0) {

--- a/src/kudu/tablet/tablet_metrics.cc
+++ b/src/kudu/tablet/tablet_metrics.cc
@@ -312,6 +312,7 @@ METRIC_DEFINE_gauge_double(tablet, average_diskrowset_height, "Average DiskRowSe
                            "replica. The larger the average height, the more "
                            "uncompacted the tablet replica is.",
                            kudu::MetricLevel::kInfo);
+METRIC_DECLARE_gauge_size(merged_entities_count_of_tablet);
 
 namespace kudu {
 namespace tablet {
@@ -319,6 +320,7 @@ namespace tablet {
 #define MINIT(x) x(METRIC_##x.Instantiate(entity))
 #define GINIT(x) x(METRIC_##x.Instantiate(entity, 0))
 #define MEANINIT(x) x(METRIC_##x.InstantiateMeanGauge(entity))
+#define HIDEINIT(x, v) x(METRIC_##x.InstantiateHidden(entity, v))
 TabletMetrics::TabletMetrics(const scoped_refptr<MetricEntity>& entity)
   : MINIT(rows_inserted),
     MINIT(rows_upserted),
@@ -363,11 +365,13 @@ TabletMetrics::TabletMetrics(const scoped_refptr<MetricEntity>& entity)
     MINIT(undo_delta_block_gc_delete_duration),
     MINIT(undo_delta_block_gc_perform_duration),
     MINIT(leader_memory_pressure_rejections),
-    MEANINIT(average_diskrowset_height) {
+    MEANINIT(average_diskrowset_height),
+    HIDEINIT(merged_entities_count_of_tablet, 1) {
 }
 #undef MINIT
 #undef GINIT
 #undef MEANINIT
+#undef HIDEINIT
 
 void TabletMetrics::AddProbeStats(const ProbeStats* stats_array, int len,
                                   Arena* work_arena) {

--- a/src/kudu/tablet/tablet_metrics.h
+++ b/src/kudu/tablet/tablet_metrics.h
@@ -101,6 +101,9 @@ struct TabletMetrics {
 
   // Compaction metrics.
   scoped_refptr<MeanGauge> average_diskrowset_height;
+
+  // Static metrics.
+  scoped_refptr<AtomicGauge<uint64_t>> merged_entities_count_of_tablet;
 };
 
 } // namespace tablet


### PR DESCRIPTION
1. METRIC_merged_entities_count_of_tablet/table/server should never
   retire because their value will never change.
2. Metric's modification epoch should be updated when AtomicGauge
   set_value() or FunctionGauge DetachToConstant().
3. Merge should abort if they are invalid for merge, FunctionGauge
   included.

Change-Id: I36ee6244964820e3326742c6902a578bf23041d1