### PR TITLE
KUDU-3304: [Alter] Support to alter table's replication factor

### DIFF
--- a/src/kudu/client/CMakeLists.txt
+++ b/src/kudu/client/CMakeLists.txt
@@ -275,5 +275,6 @@ SET_KUDU_TEST_LINK_LIBS(
 ADD_KUDU_TEST(client-test NUM_SHARDS 8 PROCESSORS 2
                           DATA_FILES ../scripts/first_argument.sh)
 ADD_KUDU_TEST(client-unittest)
+ADD_KUDU_TEST(flex_partitioning_client-test)
 ADD_KUDU_TEST(predicate-test NUM_SHARDS 4)
 ADD_KUDU_TEST(scan_token-test PROCESSORS 2)

--- a/src/kudu/client/client-test.cc
+++ b/src/kudu/client/client-test.cc
@@ -134,6 +134,7 @@ DECLARE_bool(allow_unsafe_replication_factor);
 DECLARE_bool(catalog_manager_support_live_row_count);
 DECLARE_bool(catalog_manager_support_on_disk_size);
 DECLARE_bool(client_use_unix_domain_sockets);
+DECLARE_bool(enable_per_range_hash_schemas);
 DECLARE_bool(enable_txn_system_client_init);
 DECLARE_bool(fail_dns_resolution);
 DECLARE_bool(location_mapping_by_uuid);

--- a/src/kudu/client/client.cc
+++ b/src/kudu/client/client.cc
@@ -1478,6 +1478,11 @@ KuduTableAlterer* KuduTableAlterer::DropColumn(const string& name) {
   return this;
 }
 
+KuduTableAlterer* KuduTableAlterer::SetReplicationFactor(int replication_factor) {
+  data_->set_replication_factor_to_ = replication_factor;
+  return this;
+}
+
 KuduTableAlterer* KuduTableAlterer::AddRangePartition(
     KuduPartialRow* lower_bound,
     KuduPartialRow* upper_bound,

--- a/src/kudu/client/client.h
+++ b/src/kudu/client/client.h
@@ -971,6 +971,7 @@ class KUDU_EXPORT KuduClient : public sp::enable_shared_from_this<KuduClient> {
   FRIEND_TEST(ClientTest, TestScanTimeout);
   FRIEND_TEST(ClientTest, TestWriteWithDeadMaster);
   FRIEND_TEST(MasterFailoverTest, TestPauseAfterCreateTableIssued);
+  FRIEND_TEST(MultiTServerClientTest, TestSetReplicationFactor);
 
   KuduClient();
 
@@ -1789,6 +1790,16 @@ class KUDU_EXPORT KuduTableAlterer {
   ///   Name of the column to alter.
   /// @return Raw pointer to this alterer object.
   KuduTableAlterer* DropColumn(const std::string& name);
+
+  /// Set the table's replication factor.
+  ///
+  /// @note The replication factor should be a odd number and range in
+  /// [1, --max_num_replicas]
+  ///
+  /// @param [in] replication_factor
+  ///   The table's new replication factor.
+  /// @return Raw pointer to this alterer object.
+  KuduTableAlterer* SetReplicationFactor(int replication_factor);
 
   /// Add a range partition to the table with the specified lower bound and
   /// upper bound.

--- a/src/kudu/client/flex_partitioning_client-test.cc
+++ b/src/kudu/client/flex_partitioning_client-test.cc
@@ -1,0 +1,420 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "kudu/client/client.h"
+#include "kudu/client/schema.h"
+#include "kudu/client/write_op.h"
+#include "kudu/common/partial_row.h"
+#include "kudu/gutil/ref_counted.h"
+#include "kudu/gutil/strings/substitute.h"
+#include "kudu/master/catalog_manager.h"
+#include "kudu/master/master.h"
+#include "kudu/master/mini_master.h"
+#include "kudu/mini-cluster/internal_mini_cluster.h"
+#include "kudu/util/net/sockaddr.h"
+#include "kudu/util/status.h"
+#include "kudu/util/test_macros.h"
+#include "kudu/util/test_util.h"
+
+DECLARE_bool(enable_per_range_hash_schemas);
+DECLARE_int32(heartbeat_interval_ms);
+
+using kudu::cluster::InternalMiniCluster;
+using kudu::cluster::InternalMiniClusterOptions;
+using kudu::master::CatalogManager;
+using kudu::client::sp::shared_ptr;
+using std::string;
+using std::unique_ptr;
+using std::vector;
+using strings::Substitute;
+
+namespace kudu {
+namespace client {
+
+class FlexPartitioningTest : public KuduTest {
+ public:
+  static constexpr const char* const kKeyColumn = "key";
+  static constexpr const char* const kIntValColumn = "int_val";
+  static constexpr const char* const kStringValColumn = "string_val";
+
+  FlexPartitioningTest() {
+    KuduSchemaBuilder b;
+    b.AddColumn("key")->
+        Type(KuduColumnSchema::INT32)->
+        NotNull()->
+        PrimaryKey();
+    b.AddColumn("int_val")->
+        Type(KuduColumnSchema::INT32)->
+        NotNull();
+    b.AddColumn("string_val")->
+        Type(KuduColumnSchema::STRING)->
+        Nullable();
+    CHECK_OK(b.Build(&schema_));
+  }
+
+  void SetUp() override {
+    KuduTest::SetUp();
+
+    // Reduce the TS<->Master heartbeat interval to speed up testing.
+    FLAGS_heartbeat_interval_ms = 10;
+
+    // Explicitly enable support for custom hash schemas per range partition.
+    FLAGS_enable_per_range_hash_schemas = true;
+
+    // Start minicluster and wait for tablet servers to connect to master.
+    cluster_.reset(new InternalMiniCluster(env_, InternalMiniClusterOptions()));
+    ASSERT_OK(cluster_->Start());
+
+    // Connect to the cluster.
+    ASSERT_OK(KuduClientBuilder()
+        .add_master_server_addr(
+            cluster_->mini_master()->bound_rpc_addr().ToString())
+        .Build(&client_));
+  }
+
+ protected:
+  typedef unique_ptr<KuduTableCreator::KuduRangePartition> RangePartition;
+  typedef vector<RangePartition> RangePartitions;
+
+  static Status ApplyInsert(KuduSession* session,
+                            const shared_ptr<KuduTable>& table,
+                            int32_t key_val,
+                            int32_t int_val,
+                            string string_val) {
+    unique_ptr<KuduInsert> insert(table->NewInsert());
+    RETURN_NOT_OK(insert->mutable_row()->SetInt32(kKeyColumn, key_val));
+    RETURN_NOT_OK(insert->mutable_row()->SetInt32(kIntValColumn, int_val));
+    RETURN_NOT_OK(insert->mutable_row()->SetStringCopy(
+        kStringValColumn, std::move(string_val)));
+    return session->Apply(insert.release());
+  }
+
+  Status InsertTestRows(
+      const char* table_name,
+      int32_t key_beg,
+      int32_t key_end,
+      KuduSession::FlushMode flush_mode = KuduSession::AUTO_FLUSH_SYNC) {
+    CHECK_LE(key_beg, key_end);
+    shared_ptr<KuduTable> table;
+    RETURN_NOT_OK(client_->OpenTable(table_name, &table));
+    shared_ptr<KuduSession> session = client_->NewSession();
+    RETURN_NOT_OK(session->SetFlushMode(flush_mode));
+    session->SetTimeoutMillis(60000);
+    for (int32_t key_val = key_beg; key_val < key_end; ++key_val) {
+      RETURN_NOT_OK(ApplyInsert(
+          session.get(), table, key_val, rand(), std::to_string(rand())));
+    }
+    return session->Flush();
+  }
+
+  Status CreateTable(const char* table_name, RangePartitions partitions) {
+    unique_ptr<KuduTableCreator> table_creator(client_->NewTableCreator());
+    table_creator->table_name(table_name)
+        .schema(&schema_)
+        .num_replicas(1)
+        .set_range_partition_columns({ kKeyColumn });
+
+    for (auto& p : partitions) {
+      table_creator->add_custom_range_partition(p.release());
+    }
+
+    return table_creator->Create();
+  }
+
+  RangePartition CreateRangePartition(int32_t lower_boundary = 0,
+                                      int32_t upper_boundary = 100) {
+    unique_ptr<KuduPartialRow> lower(schema_.NewRow());
+    CHECK_OK(lower->SetInt32(kKeyColumn, lower_boundary));
+    unique_ptr<KuduPartialRow> upper(schema_.NewRow());
+    CHECK_OK(upper->SetInt32(kKeyColumn, upper_boundary));
+    return unique_ptr<KuduTableCreator::KuduRangePartition>(
+        new KuduTableCreator::KuduRangePartition(lower.release(),
+                                                 upper.release()));
+  }
+
+  void CheckTabletCount(const char* table_name, int expected_count) {
+    shared_ptr<KuduTable> table;
+    ASSERT_OK(client_->OpenTable(table_name, &table));
+
+    scoped_refptr<master::TableInfo> table_info;
+    {
+      auto* cm = cluster_->mini_master(0)->master()->catalog_manager();
+      CatalogManager::ScopedLeaderSharedLock l(cm);
+      ASSERT_OK(cm->GetTableInfo(table->id(), &table_info));
+    }
+    ASSERT_EQ(expected_count, table_info->num_tablets());
+  }
+
+  KuduSchema schema_;
+  unique_ptr<InternalMiniCluster> cluster_;
+  shared_ptr<KuduClient> client_;
+};
+
+// Test for scenarios covering range partitioning with custom bucket schemas
+// specified when creating a table.
+class FlexPartitioningCreateTableTest : public FlexPartitioningTest {};
+
+// Create tables with range partitions using custom hash bucket schemas only.
+//
+// TODO(aserbin): turn the sub-scenarios with non-primary-key columns for
+//                custom hash buckets into negative ones after proper
+//                checks are added at the server side
+// TODO(aserbin): add verification based on PartitionSchema provided by
+//                KuduTable::partition_schema() once PartitionPruner
+//                recognized custom hash bucket schema for ranges
+// TODO(aserbin): add InsertTestRows() when proper key encoding is implemented
+TEST_F(FlexPartitioningCreateTableTest, CustomHashBuckets) {
+  // One-level hash bucket structure: { 3, "key" }.
+  {
+    constexpr const char* const kTableName = "3@key";
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 3, 0));
+    ASSERT_OK(CreateTable(kTableName, std::move(partitions)));
+    NO_FATALS(CheckTabletCount(kTableName, 3));
+  }
+
+  // One-level hash bucket structure with hashing on non-key column only:
+  // { 3, "int_val" }.
+  {
+    constexpr const char* const kTableName = "3@int_val";
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ kIntValColumn }, 2, 0));
+    ASSERT_OK(CreateTable(kTableName, std::move(partitions)));
+    NO_FATALS(CheckTabletCount(kTableName, 2));
+  }
+
+  // One-level hash bucket structure with hashing on non-key nullable column:
+  // { 5, "string_val" }.
+  {
+    constexpr const char* const kTableName = "3@string_val";
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ kStringValColumn }, 5, 0));
+    ASSERT_OK(CreateTable(kTableName, std::move(partitions)));
+    NO_FATALS(CheckTabletCount(kTableName, 5));
+  }
+
+  // Two-level hash bucket structure: { 3, "key" } x { 3, "key" }.
+  {
+    constexpr const char* const kTableName = "3@key_x_3@key";
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 3, 0));
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 3, 1));
+    ASSERT_OK(CreateTable(kTableName, std::move(partitions)));
+    NO_FATALS(CheckTabletCount(kTableName, 9));
+  }
+
+  // Two-level hash bucket structure: { 2, "key" } x { 3, "int_val" }.
+  {
+    constexpr const char* const kTableName = "2@key_x_3@int_val";
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 2, 0));
+    ASSERT_OK(p->add_hash_partitions({ kIntValColumn }, 3, 1));
+    ASSERT_OK(CreateTable(kTableName, std::move(partitions)));
+    NO_FATALS(CheckTabletCount(kTableName, 6));
+  }
+
+  // Two-level hash bucket structure: { 3, "key" } x { 2, "key", "int_val" }.
+  {
+    constexpr const char* const kTableName = "3@key_x_2@key:int_val";
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 3, 0));
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn, kIntValColumn }, 2, 1));
+    ASSERT_OK(CreateTable(kTableName, std::move(partitions)));
+    NO_FATALS(CheckTabletCount(kTableName, 6));
+  }
+}
+
+// Create a table with mixed set of range partitions, using both table-wide and
+// custom hash bucket schemas.
+//
+// TODO(aserbin): add verification based on PartitionSchema provided by
+//                KuduTable::partition_schema() once PartitionPruner
+//                recognized custom hash bucket schema for ranges
+// TODO(aserbin): add InsertTestRows() when proper key encoding is implemented
+TEST_F(FlexPartitioningCreateTableTest, DefaultAndCustomHashBuckets) {
+  // Create a table with the following partitions:
+  //
+  //            hash bucket
+  //   key    0               1               2               3
+  //         --------------------------------------------------------------
+  //  <111    x:{key}         x:{key}         -               -
+  // 111-222  x:{key}         x:{key}         x:{key}         -
+  // 222-333  x:{int_val}     x:{int_val}     x:{int_val}     x:{int_val}
+  // 333-444  x:{key,int_val} x:{key,int_val} -               -
+  constexpr const char* const kTableName = "DefaultAndCustomHashBuckets";
+
+  unique_ptr<KuduTableCreator> table_creator(client_->NewTableCreator());
+  table_creator->table_name(kTableName)
+      .schema(&schema_)
+      .num_replicas(1)
+      .add_hash_partitions({ kKeyColumn }, 2)
+      .set_range_partition_columns({ kKeyColumn });
+
+  // Add a range partition with the table-wide hash partitioning rules.
+  {
+    unique_ptr<KuduPartialRow> lower(schema_.NewRow());
+    ASSERT_OK(lower->SetInt32(kKeyColumn, INT32_MIN));
+    unique_ptr<KuduPartialRow> upper(schema_.NewRow());
+    ASSERT_OK(upper->SetInt32(kKeyColumn, 111));
+    table_creator->add_range_partition(lower.release(), upper.release());
+  }
+
+  // Add a range partition with custom hash sub-partitioning rules:
+  // 3 buckets with hash based on the "key" column with hash seed 1.
+  {
+    auto p = CreateRangePartition(111, 222);
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 3, 1));
+    table_creator->add_custom_range_partition(p.release());
+  }
+
+  // Add a range partition with custom hash sub-partitioning rules:
+  // 4 buckets with hash based on the "int_val" column with hash seed 2.
+  {
+    auto p = CreateRangePartition(222, 333);
+    ASSERT_OK(p->add_hash_partitions({ kIntValColumn }, 4, 2));
+    table_creator->add_custom_range_partition(p.release());
+  }
+
+  // Add a range partition with custom hash sub-partitioning rules:
+  // 3 buckets hashing on the { "key", "int_val" } columns with hash seed 3.
+  {
+    auto p = CreateRangePartition(333, 444);
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn, kIntValColumn }, 2, 3));
+    table_creator->add_custom_range_partition(p.release());
+  }
+
+  ASSERT_OK(table_creator->Create());
+  NO_FATALS(CheckTabletCount(kTableName, 11));
+
+  // Make sure it's possible to insert rows into the table.
+  //ASSERT_OK(InsertTestRows(kTableName, 111, 444));
+}
+
+// Negative tests scenarios to cover non-OK status codes for various operations
+// related to custom hash bucket schema per range.
+TEST_F(FlexPartitioningCreateTableTest, Negatives) {
+  // Try adding hash partitions on an empty set of columns.
+  {
+    auto p = CreateRangePartition();
+    const auto s = p->add_hash_partitions({}, 2, 0);
+    ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+    ASSERT_STR_CONTAINS(
+        s.ToString(), "set of columns for hash partitioning must not be empty");
+  }
+
+  // Try adding hash partitions with just one bucket.
+  {
+    auto p = CreateRangePartition();
+    const auto s = p->add_hash_partitions({ kKeyColumn }, 1, 0);
+    ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+    ASSERT_STR_CONTAINS(
+        s.ToString(),
+        "at least two buckets are required to establish hash partitioning");
+  }
+
+  // Try adding hash partition on a non-existent column: appropriate error
+  // surfaces during table creation.
+  {
+    RangePartitions partitions;
+    partitions.emplace_back(CreateRangePartition());
+    auto& p = partitions.back();
+    ASSERT_OK(p->add_hash_partitions({ "nonexistent" }, 2, 0));
+    const auto s = CreateTable("nicetry", std::move(partitions));
+    ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+    ASSERT_STR_CONTAINS(s.ToString(), "unknown column: name: \"nonexistent\"");
+  }
+
+  // Try adding creating a table where both range splits and custom hash bucket
+  // schema per partition are both specified -- that should not be possible.
+  {
+    RangePartition p(CreateRangePartition(0, 100));
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 2, 0));
+
+    unique_ptr<KuduPartialRow> split(schema_.NewRow());
+    ASSERT_OK(split->SetInt32(kKeyColumn, 50));
+
+    unique_ptr<KuduTableCreator> creator(client_->NewTableCreator());
+    creator->table_name("nicetry")
+        .schema(&schema_)
+        .num_replicas(1)
+        .set_range_partition_columns({ kKeyColumn })
+        .add_range_partition_split(split.release())
+        .add_custom_range_partition(p.release());
+
+    const auto s = creator->Create();
+    ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+    ASSERT_STR_CONTAINS(
+        s.ToString(),
+        "split rows and custom hash bucket schemas for ranges are incompatible: "
+        "choose one or the other");
+  }
+
+  // Same as the sub-scenario above, but using deprecated client API to specify
+  // so-called split rows.
+  {
+    RangePartition p(CreateRangePartition(0, 100));
+    ASSERT_OK(p->add_hash_partitions({ kKeyColumn }, 2, 0));
+
+    unique_ptr<KuduPartialRow> split_row(schema_.NewRow());
+    ASSERT_OK(split_row->SetInt32(kKeyColumn, 50));
+
+    unique_ptr<KuduTableCreator> creator(client_->NewTableCreator());
+    creator->table_name("nicetry")
+        .schema(&schema_)
+        .num_replicas(1)
+        .set_range_partition_columns({ kKeyColumn })
+        .add_custom_range_partition(p.release());
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    creator->split_rows({ split_row.release() });
+#pragma GCC diagnostic pop
+
+    const auto s = creator->Create();
+    ASSERT_TRUE(s.IsInvalidArgument()) << s.ToString();
+    ASSERT_STR_CONTAINS(
+        s.ToString(),
+        "split rows and custom hash bucket schemas for ranges are incompatible: "
+        "choose one or the other");
+  }
+}
+
+} // namespace client
+} // namespace kudu

--- a/src/kudu/client/meta_cache.cc
+++ b/src/kudu/client/meta_cache.cc
@@ -950,18 +950,16 @@ Status MetaCache::ProcessLookupResponse(const LookupRpc& rpc,
   VLOG(2) << "Processing master response for " << rpc.ToString()
           << ". Response: " << pb_util::SecureShortDebugString(rpc.resp());
 
-  if (rpc.resp().tablet_locations().empty()) {
-    // If there are no tablets in the response, then the table is empty. If
-    // there were any tablets in the table they would have been returned, since
-    // the master guarantees that if the partition key falls in a non-covered
-    // range, the previous tablet will be returned, and we did not set an upper
-    // bound partition key on the request.
-    DCHECK(!rpc.req().has_partition_key_end());
-  }
+  // If there are no tablets in the response, then the table is empty. If
+  // there were any tablets in the table they would have been returned, since
+  // the master guarantees that if the partition key falls in a non-covered
+  // range, the previous tablet will be returned, and we did not set an upper
+  // bound partition key on the request.
+  DCHECK(!rpc.resp().tablet_locations().empty() ||
+         !rpc.req().has_partition_key_end());
 
   return ProcessGetTableLocationsResponse(rpc.table(), rpc.partition_key(), rpc.is_exact_lookup(),
       rpc.resp(), cache_entry, max_returned_locations);
-
 }
 
 Status MetaCache::ProcessGetTabletLocationsResponse(const string& tablet_id,

--- a/src/kudu/client/partitioner-internal.cc
+++ b/src/kudu/client/partitioner-internal.cc
@@ -39,7 +39,7 @@ namespace client {
 Status KuduPartitionerBuilder::Data::Build(KuduPartitioner** partitioner) {
   // If any of the builder calls had generated a bad status, then return it here.
   RETURN_NOT_OK(status_);
-  unique_ptr<KuduPartitioner::Data> ret_data(new KuduPartitioner::Data());
+  unique_ptr<KuduPartitioner::Data> ret_data(new KuduPartitioner::Data);
 
   auto deadline = MonoTime::Now() + timeout_;
   auto mc = table_->client()->data_->meta_cache_;

--- a/src/kudu/client/table_alterer-internal.cc
+++ b/src/kudu/client/table_alterer-internal.cc
@@ -63,6 +63,7 @@ Status KuduTableAlterer::Data::ToRequest(AlterTableRequestPB* req) {
       !set_comment_to_.is_initialized() &&
       !disk_size_limit_ &&
       !row_count_limit_ &&
+      !set_replication_factor_to_.is_initialized() &&
       steps_.empty()) {
     return Status::InvalidArgument("No alter steps provided");
   }
@@ -82,6 +83,9 @@ Status KuduTableAlterer::Data::ToRequest(AlterTableRequestPB* req) {
   }
   if (set_comment_to_.is_initialized()) {
     req->set_new_table_comment(set_comment_to_.get());
+  }
+  if (set_replication_factor_to_.is_initialized()) {
+    req->set_num_replicas(set_replication_factor_to_.get());
   }
 
   if (schema_ != nullptr) {

--- a/src/kudu/client/table_alterer-internal.h
+++ b/src/kudu/client/table_alterer-internal.h
@@ -77,6 +77,7 @@ class KuduTableAlterer::Data {
   boost::optional<std::string> rename_to_;
   boost::optional<std::string> set_owner_to_;
   boost::optional<std::string> set_comment_to_;
+  boost::optional<int> set_replication_factor_to_;
 
   boost::optional<std::map<std::string, std::string>> new_extra_configs_;
 

--- a/src/kudu/client/table_creator-internal.h
+++ b/src/kudu/client/table_creator-internal.h
@@ -14,12 +14,13 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#ifndef KUDU_CLIENT_TABLE_CREATOR_INTERNAL_H
-#define KUDU_CLIENT_TABLE_CREATOR_INTERNAL_H
+#pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <boost/optional/optional.hpp>
@@ -29,17 +30,31 @@
 #include "kudu/common/partial_row.h"
 #include "kudu/gutil/macros.h"
 #include "kudu/util/monotime.h"
+#include "kudu/util/status.h"
 
 namespace kudu {
-
 namespace client {
 
 class KuduSchema;
 
+struct HashBucketSchema {
+  HashBucketSchema(std::vector<std::string> column_names,
+                   uint32_t num_buckets,
+                   int32_t seed)
+      : column_names(std::move(column_names)),
+        num_buckets(num_buckets),
+        seed(seed) {
+  }
+
+  const std::vector<std::string> column_names;
+  const uint32_t num_buckets;
+  const int32_t seed;
+};
+
 class KuduTableCreator::Data {
  public:
   explicit Data(KuduClient* client);
-  ~Data();
+  ~Data() = default;
 
   KuduClient* client_;
 
@@ -49,14 +64,7 @@ class KuduTableCreator::Data {
 
   std::vector<std::unique_ptr<KuduPartialRow>> range_partition_splits_;
 
-  struct RangePartition {
-    std::unique_ptr<KuduPartialRow> lower_bound;
-    std::unique_ptr<KuduPartialRow> upper_bound;
-    RangePartitionBound lower_bound_type;
-    RangePartitionBound upper_bound_type;
-  };
-
-  std::vector<RangePartition> range_partition_bounds_;
+  std::vector<std::unique_ptr<KuduRangePartition>> range_partitions_;
 
   PartitionSchemaPB partition_schema_;
 
@@ -80,7 +88,29 @@ class KuduTableCreator::Data {
   DISALLOW_COPY_AND_ASSIGN(Data);
 };
 
+class KuduTableCreator::KuduRangePartition::Data {
+ public:
+  Data(KuduPartialRow* lower_bound,
+       KuduPartialRow* upper_bound,
+       RangePartitionBound lower_bound_type,
+       RangePartitionBound upper_bound_type);
+  ~Data() = default;
+
+  Status add_hash_partitions(const std::vector<std::string>& column_names,
+                             int32_t num_buckets,
+                             int32_t seed);
+
+  const RangePartitionBound lower_bound_type_;
+  const RangePartitionBound upper_bound_type_;
+
+  std::unique_ptr<KuduPartialRow> lower_bound_;
+  std::unique_ptr<KuduPartialRow> upper_bound_;
+
+  std::vector<HashBucketSchema> hash_bucket_schemas_;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(Data);
+};
+
 } // namespace client
 } // namespace kudu
-
-#endif

--- a/src/kudu/common/partition.cc
+++ b/src/kudu/common/partition.cc
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <iterator>
 #include <memory>
+#include <ostream>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -306,6 +307,9 @@ Status PartitionSchema::ToPB(const Schema& schema, PartitionSchemaPB* pb) const 
 
 template<typename Row>
 Status PartitionSchema::EncodeKeyImpl(const Row& row, string* buf) const {
+  // TODO(aserbin): update the implementation and remove the DCHECK() below
+  DCHECK(ranges_with_hash_schemas_.empty())
+      << "ranges with custom hash schemas are not yet supported";
   const KeyEncoder<string>& hash_encoder = GetKeyEncoder<string>(GetTypeInfo(UINT32));
 
   for (const HashBucketSchema& hash_bucket_schema : hash_bucket_schemas_) {
@@ -892,6 +896,10 @@ string PartitionSchema::PartitionKeyDebugString(const KuduPartialRow& row) const
 }
 
 string PartitionSchema::PartitionKeyDebugString(Slice key, const Schema& schema) const {
+  // TODO(aserbin): update the implementation and remove the DCHECK() below
+  DCHECK(ranges_with_hash_schemas_.empty())
+      << "ranges with custom hash schemas are not yet supported";
+
   vector<string> components;
 
   size_t hash_components_size = kEncodedBucketSize * hash_bucket_schemas_.size();

--- a/src/kudu/integration-tests/alter_table-test.cc
+++ b/src/kudu/integration-tests/alter_table-test.cc
@@ -45,6 +45,7 @@
 #include "kudu/common/partial_row.h"
 #include "kudu/common/schema.h"
 #include "kudu/common/wire_protocol.h"
+#include "kudu/consensus/metadata.pb.h"
 #include "kudu/consensus/raft_consensus.h"
 #include "kudu/gutil/port.h"
 #include "kudu/gutil/ref_counted.h"
@@ -70,6 +71,7 @@
 #include "kudu/util/status.h"
 #include "kudu/util/test_macros.h"
 #include "kudu/util/test_util.h"
+#include "kudu/util/threadpool.h"
 
 DECLARE_bool(enable_maintenance_manager);
 DECLARE_bool(log_inject_latency);
@@ -138,7 +140,7 @@ class AlterTableTest : public KuduTest {
     KuduTest::SetUp();
 
     InternalMiniClusterOptions opts;
-    opts.num_tablet_servers = num_replicas();
+    opts.num_tablet_servers = num_tservers();
     cluster_.reset(new InternalMiniCluster(env_, opts));
     ASSERT_OK(cluster_->Start());
 
@@ -155,9 +157,9 @@ class AlterTableTest : public KuduTest {
              .num_replicas(num_replicas())
              .Create());
 
-    if (num_replicas() == 1) {
-      tablet_replica_ = LookupTabletReplica();
-      ASSERT_OK(tablet_replica_->consensus()->WaitUntilLeaderForTests(MonoDelta::FromSeconds(10)));
+    if (num_replicas() > 0) {
+      tablet_replica_ = LookupLeaderTabletReplica(MonoDelta::FromSeconds(5));
+      CHECK(tablet_replica_);
     }
     LOG(INFO) << "Tablet successfully located";
   }
@@ -167,11 +169,41 @@ class AlterTableTest : public KuduTest {
     cluster_->Shutdown();
   }
 
-  scoped_refptr<TabletReplica> LookupTabletReplica() {
-    vector<scoped_refptr<TabletReplica> > replicas;
-    cluster_->mini_tablet_server(0)->server()->tablet_manager()->GetTabletReplicas(&replicas);
-    CHECK_EQ(1, replicas.size());
-    return replicas[0];
+  scoped_refptr<TabletReplica> LookupLeaderTabletReplica(const MonoDelta& timeout) {
+    scoped_refptr<TabletReplica> leader_replica;
+    MonoTime deadline = MonoTime::Now() + timeout;
+    std::unique_ptr<ThreadPool> pool;
+    CHECK_OK(ThreadPoolBuilder("WaitUntilLeader.Pool")
+                     .set_max_threads(num_tservers())
+                     .set_idle_timeout(MonoDelta::FromMilliseconds(10))
+                     .Build(&pool));
+    std::atomic<bool> got_leader(false);
+    for (int i = 0; i < num_tservers(); ++i) {
+      CHECK_OK(pool->Submit(
+        [this, i, deadline, &got_leader, &leader_replica]() {
+          while (!got_leader && MonoTime::Now() < deadline) {
+            vector<scoped_refptr<TabletReplica> > replicas;
+            cluster_->mini_tablet_server(i)->server()->tablet_manager()
+                ->GetTabletReplicas(&replicas);
+            if (replicas.empty()) {
+              SleepFor(MonoDelta::FromMilliseconds(50));
+              continue;
+            }
+
+            MonoDelta remaining_timeout = deadline - MonoTime::Now();
+            auto s = replicas[0]->consensus()->WaitUntilLeaderForTests(remaining_timeout);
+            if (!s.ok()) {
+              SleepFor(MonoDelta::FromMilliseconds(50));
+              continue;
+            }
+
+            got_leader = true;
+            leader_replica = replicas[0];
+          }
+      }));
+    }
+    pool->Wait();
+    return leader_replica;
   }
 
   void ShutdownTS() {
@@ -196,7 +228,7 @@ class AlterTableTest : public KuduTest {
 
     ASSERT_OK(cluster_->mini_tablet_server(idx)->WaitStarted());
     if (idx == 0) {
-      tablet_replica_ = LookupTabletReplica();
+      tablet_replica_ = LookupLeaderTabletReplica(MonoDelta::FromSeconds(5));
     }
   }
 
@@ -231,6 +263,38 @@ class AlterTableTest : public KuduTest {
     table_alterer->AddColumn(column_name)->Type(KuduColumnSchema::INT32)->
         NotNull()->Default(KuduValue::FromInt(default_value));
     return table_alterer->timeout(timeout)->Alter();
+  }
+
+  Status SetReplicationFactor(const string& table_name,
+                              int32_t replication_factor) {
+    unique_ptr<KuduTableAlterer> table_alterer(client_->NewTableAlterer(table_name));
+    table_alterer->SetReplicationFactor(replication_factor);
+    return table_alterer->timeout(MonoDelta::FromSeconds(60))->Alter();
+  }
+
+  void VerifyTabletReplicaCount(int32_t replication_factor) {
+    ASSERT_EVENTUALLY([&] {
+      ASSERT_EQ(replication_factor, tablet_replica_->consensus()->CommittedConfig().peers().size());
+
+      scoped_refptr<TabletReplica> replica;
+      int actual_replica_count = 0;
+      for (int i = 0; i < num_tservers(); i++) {
+        vector<scoped_refptr<TabletReplica>> replicas;
+        cluster_->mini_tablet_server(i)->server()->tablet_manager()->GetTabletReplicas(&replicas);
+        if (replicas.empty()) continue;
+        ASSERT_EQ(1, replicas.size());
+        if (!replicas[0]->tablet()) continue;
+
+        if (!replica) {
+          replica = replicas[0];
+        } else {
+          ASSERT_EQ(replica->tablet()->tablet_id(), replicas[0]->tablet()->tablet_id());
+          ASSERT_TRUE(replica->tablet()->schema()->Equals(*(replicas[0]->tablet()->schema())));
+        }
+        ++actual_replica_count;
+      }
+      ASSERT_EQ(replication_factor, actual_replica_count);
+    });
   }
 
   enum VerifyPattern {
@@ -290,6 +354,7 @@ class AlterTableTest : public KuduTest {
 
  protected:
   virtual int num_replicas() const { return 1; }
+  virtual int num_tservers() const { return 1; }
 
   static const char* const kTableName;
 
@@ -313,7 +378,8 @@ class AlterTableTest : public KuduTest {
 // Subclass which creates three servers and a replicated cluster.
 class ReplicatedAlterTableTest : public AlterTableTest {
  protected:
-  virtual int num_replicas() const OVERRIDE { return 3; }
+  int num_replicas() const override { return 3; }
+  int num_tservers() const override { return num_replicas() + 1; }
 };
 
 const char* const AlterTableTest::kTableName = "fake-table";
@@ -2144,6 +2210,60 @@ TEST_F(ReplicatedAlterTableTest, AlterTableAndDropTablet) {
         fill_row(i).release(),
         fill_row(i + 1).release())->wait(false)->Alter());
   }
+  ASSERT_OK(client_->DeleteTable(kTableName));
+}
+
+TEST_F(ReplicatedAlterTableTest, AlterReplicationFactor) {
+  // 1. The default replication factor is 3.
+  ASSERT_EQ(0, tablet_replica_->tablet()->metadata()->schema_version());
+  NO_FATALS(VerifyTabletReplicaCount(3));
+
+  // 2. Set replication factor to 1.
+  ASSERT_OK(SetReplicationFactor(kTableName, 1));
+  NO_FATALS(VerifyTabletReplicaCount(1));
+  ASSERT_EQ(1, tablet_replica_->tablet()->metadata()->schema_version());
+
+  // 3. Set replication factor to 3.
+  ASSERT_OK(SetReplicationFactor(kTableName, 3));
+  NO_FATALS(VerifyTabletReplicaCount(3));
+  ASSERT_EQ(2, tablet_replica_->tablet()->metadata()->schema_version());
+
+  // 4. Set replication factor to 3 again.
+  ASSERT_OK(SetReplicationFactor(kTableName, 3));
+  NO_FATALS(VerifyTabletReplicaCount(3));
+  ASSERT_EQ(2, tablet_replica_->tablet()->metadata()->schema_version());
+
+  // 5. Set replication factor to 5, while there are only 4 tservers inthe cluster.
+  auto s = SetReplicationFactor(kTableName, 5);
+  ASSERT_TRUE(s.IsInvalidArgument());
+  ASSERT_STR_CONTAINS(s.ToString(), "not enough live tablet servers to alter a table with the"
+                                    " requested replication factor 5; 4 tablet servers are alive");
+  NO_FATALS(VerifyTabletReplicaCount(3));
+  ASSERT_EQ(2, tablet_replica_->tablet()->metadata()->schema_version());
+
+  // 6. Set replication factor to -1, it will fail.
+  s = SetReplicationFactor(kTableName, -1);
+  ASSERT_TRUE(s.IsInvalidArgument());
+  ASSERT_STR_CONTAINS(s.ToString(), "illegal replication factor -1: minimum allowed replication"
+                                    " factor is 1 (controlled by --min_num_replicas)");
+  NO_FATALS(VerifyTabletReplicaCount(3));
+  ASSERT_EQ(2, tablet_replica_->tablet()->metadata()->schema_version());
+
+  // 7. Set replication factor to 2, it will fail.
+  s = SetReplicationFactor(kTableName, 2);
+  ASSERT_TRUE(s.IsInvalidArgument());
+  ASSERT_STR_CONTAINS(s.ToString(), "illegal replication factor 2: replication factor must be odd");
+  NO_FATALS(VerifyTabletReplicaCount(3));
+  ASSERT_EQ(2, tablet_replica_->tablet()->metadata()->schema_version());
+
+  // 8. Set replication factor to 9, it will fail.
+  s = SetReplicationFactor(kTableName, 9);
+  ASSERT_TRUE(s.IsInvalidArgument());
+  ASSERT_STR_CONTAINS(s.ToString(), "illegal replication factor 9: maximum allowed replication "
+                                    "factor is 7 (controlled by --max_num_replicas)");
+  NO_FATALS(VerifyTabletReplicaCount(3));
+  ASSERT_EQ(2, tablet_replica_->tablet()->metadata()->schema_version());
+
   ASSERT_OK(client_->DeleteTable(kTableName));
 }
 

--- a/src/kudu/master/catalog_manager.cc
+++ b/src/kudu/master/catalog_manager.cc
@@ -257,6 +257,12 @@ DEFINE_bool(catalog_manager_check_ts_count_for_create_table, true,
             "a table to be created.");
 TAG_FLAG(catalog_manager_check_ts_count_for_create_table, hidden);
 
+DEFINE_bool(catalog_manager_check_ts_count_for_alter_table, true,
+            "Whether the master should ensure that there are enough live tablet "
+            "servers to satisfy the provided replication count before allowing "
+            "a table to be altered.");
+TAG_FLAG(catalog_manager_check_ts_count_for_alter_table, hidden);
+
 DEFINE_int32(table_locations_ttl_ms, 5 * 60 * 1000, // 5 minutes
              "Maximum time in milliseconds which clients may cache table locations. "
              "New range partitions may not be visible to existing client instances "
@@ -1880,79 +1886,9 @@ Status CatalogManager::CreateTable(const CreateTableRequestPB* orig_req,
   }
 
   const auto num_replicas = req.num_replicas();
-  if (num_replicas > FLAGS_max_num_replicas) {
-    return SetupError(Status::InvalidArgument(
-        Substitute("illegal replication factor $0: maximum allowed replication "
-                   "factor is $1 (controlled by --max_num_replicas)",
-                   num_replicas, FLAGS_max_num_replicas)),
-        resp, MasterErrorPB::REPLICATION_FACTOR_TOO_HIGH);
-  }
-  if (num_replicas < FLAGS_min_num_replicas) {
-    return SetupError(Status::InvalidArgument(
-        Substitute("illegal replication factor $0: minimum allowed replication "
-                   "factor is $1 (controlled by --min_num_replicas)",
-            num_replicas, FLAGS_min_num_replicas)),
-        resp, MasterErrorPB::ILLEGAL_REPLICATION_FACTOR);
-  }
-  // Reject create table with even replication factors, unless master flag
-  // allow_unsafe_replication_factor is on.
-  if (num_replicas % 2 == 0 && !FLAGS_allow_unsafe_replication_factor) {
-    return SetupError(Status::InvalidArgument(
-        Substitute("illegal replication factor $0: replication factor must be odd",
-                   num_replicas)),
-        resp, MasterErrorPB::EVEN_REPLICATION_FACTOR);
-  }
-
-  // Verify that the number of replicas isn't larger than the number of live tablet
-  // servers.
-  TSDescriptorVector ts_descs;
-  master_->ts_manager()->GetDescriptorsAvailableForPlacement(&ts_descs);
-  const auto num_live_tservers = ts_descs.size();
-  if (FLAGS_catalog_manager_check_ts_count_for_create_table && num_replicas > num_live_tservers) {
-    // Note: this error message is matched against in master-stress-test.
-    return SetupError(Status::InvalidArgument(Substitute(
-            "not enough live tablet servers to create a table with the requested replication "
-            "factor $0; $1 tablet servers are alive", req.num_replicas(), num_live_tservers)),
-        resp, MasterErrorPB::REPLICATION_FACTOR_TOO_HIGH);
-  }
-
-  // Verify that the total number of replicas is reasonable.
-  //
-  // Table creation can generate a fair amount of load, both in the form of RPC
-  // traffic (due to Raft leader elections) and disk I/O (due to durably writing
-  // several files during both replica creation and leader elections).
-  //
-  // Ideally we would have more effective ways of mitigating this load (such
-  // as more efficient on-disk metadata management), but in lieu of that, we
-  // employ this coarse-grained check that prohibits up-front creation of too
-  // many replicas.
-  //
-  // Note: non-replicated tables are exempt because, by not using replication,
-  // they do not generate much of the load described above.
-  const auto max_replicas_total = FLAGS_max_create_tablets_per_ts * num_live_tservers;
-  if (num_replicas > 1 &&
-      max_replicas_total > 0 &&
-      partitions.size() * num_replicas > max_replicas_total) {
-    return SetupError(Status::InvalidArgument(Substitute(
-        "the requested number of tablet replicas is over the maximum permitted "
-        "at creation time ($0), additional tablets may be added by adding "
-        "range partitions to the table post-creation", max_replicas_total)),
-                      resp, MasterErrorPB::TOO_MANY_TABLETS);
-  }
-
-  // Warn if the number of live tablet servers is not enough to re-replicate
-  // a failed replica of the tablet.
-  const auto num_ts_needed_for_rereplication =
-      num_replicas + (FLAGS_raft_prepare_replacement_before_eviction ? 1 : 0);
-  if (num_replicas > 1 && num_ts_needed_for_rereplication > num_live_tservers) {
-    LOG(WARNING) << Substitute(
-        "The number of live tablet servers is not enough to re-replicate a "
-        "tablet replica of the newly created table $0 in case of a server "
-        "failure: $1 tablet servers would be needed, $2 are available. "
-        "Consider bringing up more tablet servers.",
-        normalized_table_name, num_ts_needed_for_rereplication,
-        num_live_tservers);
-  }
+  RETURN_NOT_OK(ValidateNumberReplicas(normalized_table_name,
+                                       resp, ValidateType::kCreateTable,
+                                       partitions.size(), num_replicas));
 
   // Verify the table's extra configuration properties.
   TableExtraConfigPB extra_config_pb;
@@ -3160,7 +3096,20 @@ Status CatalogManager::AlterTable(const AlterTableRequestPB& req,
           resp, MasterErrorPB::UNKNOWN_ERROR));
   }
 
-  // 8. Alter table's extra configuration properties.
+  // 8. Alter table's replication factor.
+  bool num_replicas_changed = false;
+  if (req.has_num_replicas()) {
+    int num_replicas = req.num_replicas();
+    RETURN_NOT_OK(ValidateNumberReplicas(normalized_table_name,
+                                         resp, ValidateType::kAlterTable,
+                                         boost::none, num_replicas));
+    if (num_replicas != l.data().pb.num_replicas()) {
+      num_replicas_changed = true;
+      l.mutable_data()->pb.set_num_replicas(num_replicas);
+    }
+  }
+
+  // 9. Alter table's extra configuration properties.
   if (!req.new_extra_configs().empty()) {
     TRACE("Apply alter extra-config");
     Map<string, string> new_extra_configs;
@@ -3181,19 +3130,21 @@ Status CatalogManager::AlterTable(const AlterTableRequestPB& req,
   bool has_metadata_changes = has_schema_changes ||
       req.has_new_table_name() || req.has_new_table_owner() ||
       !req.new_extra_configs().empty() || req.has_disk_size_limit() ||
-      req.has_row_count_limit() || req.has_new_table_comment();
+      req.has_row_count_limit() || req.has_new_table_comment() ||
+      num_replicas_changed;
   // Set to true if there are partitioning changes.
   bool has_partitioning_changes = !alter_partitioning_steps.empty();
   // Set to true if metadata changes need to be applied to existing tablets.
   bool has_metadata_changes_for_existing_tablets =
-    has_metadata_changes && table->num_tablets() > tablets_to_drop.size();
+    has_metadata_changes &&
+    (table->num_tablets() > tablets_to_drop.size() || num_replicas_changed);
 
   // Skip empty requests...
   if (!has_metadata_changes && !has_partitioning_changes) {
     return Status::OK();
   }
 
-  // 9. Serialize the schema and increment the version number.
+  // 10. Serialize the schema and increment the version number.
   if (has_metadata_changes_for_existing_tablets && !l.data().pb.has_fully_applied_schema()) {
     l.mutable_data()->pb.mutable_fully_applied_schema()->CopyFrom(l.data().pb.schema());
   }
@@ -3218,7 +3169,7 @@ Status CatalogManager::AlterTable(const AlterTableRequestPB& req,
   TabletMetadataGroupLock tablets_to_add_lock(LockMode::WRITE);
   TabletMetadataGroupLock tablets_to_drop_lock(LockMode::RELEASED);
 
-  // 10. Update sys-catalog with the new table schema and tablets to add/drop.
+  // 11. Update sys-catalog with the new table schema and tablets to add/drop.
   TRACE("Updating metadata on disk");
   {
     SysCatalogTable::Actions actions;
@@ -3248,7 +3199,7 @@ Status CatalogManager::AlterTable(const AlterTableRequestPB& req,
     }
   }
 
-  // 11. Commit the in-memory state.
+  // 12. Commit the in-memory state.
   TRACE("Committing alterations to in-memory state");
   {
     // Commit new tablet in-memory state. This doesn't require taking the global
@@ -3340,7 +3291,7 @@ Status CatalogManager::AlterTable(const AlterTableRequestPB& req,
     SendDeleteTabletRequest(tablet, l, deletion_msg);
   }
 
-  // 12. Invalidate/purge corresponding entries in the table locations cache.
+  // 13. Invalidate/purge corresponding entries in the table locations cache.
   if (table_locations_cache_ &&
       (!tablets_to_add.empty() || !tablets_to_drop.empty())) {
     table_locations_cache_->Remove(table->id());
@@ -5895,6 +5846,95 @@ Status CatalogManager::WaitForNotificationLogListenerCatchUp(RespClass* resp,
       MasterErrorPB::HIVE_METASTORE_ERROR;
     return SetupError(s, resp, code);
   }
+  return Status::OK();
+}
+
+template<typename RespClass>
+Status CatalogManager::ValidateNumberReplicas(const std::string& normalized_table_name,
+                                              RespClass* resp, ValidateType type,
+                                              const boost::optional<int>& partitions_count,
+                                              int num_replicas) {
+  if (num_replicas > FLAGS_max_num_replicas) {
+    return SetupError(Status::InvalidArgument(
+        Substitute("illegal replication factor $0: maximum allowed replication "
+                   "factor is $1 (controlled by --max_num_replicas)",
+                   num_replicas, FLAGS_max_num_replicas)),
+        resp, MasterErrorPB::REPLICATION_FACTOR_TOO_HIGH);
+  }
+  if (num_replicas < FLAGS_min_num_replicas) {
+    return SetupError(Status::InvalidArgument(
+        Substitute("illegal replication factor $0: minimum allowed replication "
+                   "factor is $1 (controlled by --min_num_replicas)",
+            num_replicas, FLAGS_min_num_replicas)),
+        resp, MasterErrorPB::ILLEGAL_REPLICATION_FACTOR);
+  }
+  // Reject create/alter table with even replication factors, unless master flag
+  // allow_unsafe_replication_factor is on.
+  if (num_replicas % 2 == 0 && !FLAGS_allow_unsafe_replication_factor) {
+    return SetupError(Status::InvalidArgument(
+        Substitute("illegal replication factor $0: replication factor must be odd",
+                   num_replicas)),
+        resp, MasterErrorPB::EVEN_REPLICATION_FACTOR);
+  }
+
+  // Verify that the number of replicas isn't larger than the number of live tablet
+  // servers.
+  TSDescriptorVector ts_descs;
+  master_->ts_manager()->GetDescriptorsAvailableForPlacement(&ts_descs);
+  const auto num_live_tservers = ts_descs.size();
+  if ((type == ValidateType::kCreateTable ? FLAGS_catalog_manager_check_ts_count_for_create_table :
+                                            FLAGS_catalog_manager_check_ts_count_for_alter_table) &&
+      num_replicas > num_live_tservers) {
+    // Note: this error message is matched against in master-stress-test.
+    return SetupError(Status::InvalidArgument(Substitute(
+        "not enough live tablet servers to $0 a table with the requested replication "
+        "factor $1; $2 tablet servers are alive",
+        type == ValidateType::kCreateTable ? "create" : "alter",
+        num_replicas, num_live_tservers)),
+                      resp, MasterErrorPB::REPLICATION_FACTOR_TOO_HIGH);
+  }
+
+  if (type == ValidateType::kCreateTable) {
+    // Verify that the total number of replicas is reasonable.
+    //
+    // Table creation can generate a fair amount of load, both in the form of RPC
+    // traffic (due to Raft leader elections) and disk I/O (due to durably writing
+    // several files during both replica creation and leader elections).
+    //
+    // Ideally we would have more effective ways of mitigating this load (such
+    // as more efficient on-disk metadata management), but in lieu of that, we
+    // employ this coarse-grained check that prohibits up-front creation of too
+    // many replicas.
+    //
+    // Note: non-replicated tables are exempt because, by not using replication,
+    // they do not generate much of the load described above.
+    const auto max_replicas_total = FLAGS_max_create_tablets_per_ts * num_live_tservers;
+    if (num_replicas > 1 && max_replicas_total > 0 &&
+        *partitions_count * num_replicas > max_replicas_total) {
+      return SetupError(Status::InvalidArgument(Substitute(
+                            "the requested number of tablet replicas is over the maximum permitted "
+                            "at creation time ($0), additional tablets may be added by adding "
+                            "range partitions to the table post-creation",
+                            max_replicas_total)),
+                        resp,
+                        MasterErrorPB::TOO_MANY_TABLETS);
+    }
+  }
+
+  // Warn if the number of live tablet servers is not enough to re-replicate
+  // a failed replica of the tablet.
+  const auto num_ts_needed_for_rereplication =
+      num_replicas + (FLAGS_raft_prepare_replacement_before_eviction ? 1 : 0);
+  if (num_replicas > 1 && num_ts_needed_for_rereplication > num_live_tservers) {
+    LOG(WARNING) << Substitute(
+        "The number of live tablet servers is not enough to re-replicate a "
+        "tablet replica of the $0 table $1 in case of a server "
+        "failure: $2 tablet servers would be needed, $3 are available. "
+        "Consider bringing up more tablet servers.",
+        type == ValidateType::kCreateTable ? "newly created" : "altering", normalized_table_name,
+        num_ts_needed_for_rereplication, num_live_tservers);
+  }
+
   return Status::OK();
 }
 

--- a/src/kudu/master/catalog_manager.h
+++ b/src/kudu/master/catalog_manager.h
@@ -1139,6 +1139,16 @@ class CatalogManager : public tserver::TabletReplicaLookupIf {
   Status WaitForNotificationLogListenerCatchUp(RespClass* resp,
                                                rpc::RpcContext* rpc) WARN_UNUSED_RESULT;
 
+  enum class ValidateType {
+    kCreateTable = 0,
+    kAlterTable,
+  };
+  template<typename RespClass>
+  Status ValidateNumberReplicas(const std::string& normalized_table_name,
+                                RespClass* resp, ValidateType type,
+                                const boost::optional<int>& partitions_count,
+                                int num_replicas);
+
   // TODO(unknown): the maps are a little wasteful of RAM, since the TableInfo/TabletInfo
   // objects have a copy of the string key. But STL doesn't make it
   // easy to make a "gettable set".

--- a/src/kudu/master/master.cc
+++ b/src/kudu/master/master.cc
@@ -524,10 +524,10 @@ Status Master::AddMaster(const HostPort& hp, rpc::RpcContext* rpc) {
     const auto& config = consensus->CommittedConfig();
     DCHECK_EQ(1, config.peers_size());
     if (!config.peers(0).has_last_known_addr()) {
-      return Status::IllegalState("'last_known_addr' field in single master Raft configuration not "
-                                  "set. Please restart master with --master_addresses flag set "
-                                  "to the single master which will populate the 'last_known_addr' "
-                                  "field.");
+      return Status::InvalidArgument("'last_known_addr' field in single master Raft configuration "
+                                     "not set. Please restart master with --master_addresses flag "
+                                     "set to the single master which will populate the "
+                                     "'last_known_addr' field.");
     }
   }
 

--- a/src/kudu/master/master.proto
+++ b/src/kudu/master/master.proto
@@ -741,6 +741,7 @@ message AlterTableRequestPB {
   optional int64 row_count_limit = 9;
 
   optional string new_table_comment = 10;
+  optional int32 num_replicas = 11;
 }
 
 message AlterTableResponsePB {

--- a/src/kudu/master/master.proto
+++ b/src/kudu/master/master.proto
@@ -509,17 +509,24 @@ message CreateTableRequestPB {
   required SchemaPB schema = 2;
   // repeated bytes pre_split_keys = 3;
   // repeated PartialRowPB split_rows = 5;
+
   // Holds either the split rows or the range bounds (or both) of the table.
   optional RowOperationsPB split_rows_range_bounds = 6;
+
   // Holds the table's partition schema, the partition schema's hash bucket schemas
   // are the default for any range where 'range_hash_schemas' is empty.
   optional PartitionSchemaPB partition_schema = 7;
-  // Holds the hash bucket schemas for each range during table creation.
-  // Only populated when 'split_rows_range_bounds' specifies range bounds, must be empty if any
-  // split rows are specified. If this field is set, its size must match the number of ranges
-  // specified by range bounds and they must be in the same order. If this field is empty,
-  // 'partition_schema' is assumed for every range bound.
+
+  // Holds the hash bucket schemas for each range during table creation. Only
+  // populated when 'split_rows_range_bounds' specifies range bounds, must not
+  // be present if any split rows are specified. If this field is present, its
+  // size must match the number of ranges specified by range bounds and they
+  // must be in the same order. If this field is absent, 'partition_schema' is
+  // assumed for every range bound.
   repeated PartitionSchemaPB.PerRangeHashBucketSchemasPB range_hash_schemas = 12;
+
+  // Number of replicas for a partition/tablet, a.k.a. table's replication
+  // factor. All tablets of the same table has same replication factor.
   optional int32 num_replicas = 4;
 
   // If set, uses the provided value as the table owner when creating the table.

--- a/src/kudu/thrift/client.h
+++ b/src/kudu/thrift/client.h
@@ -340,6 +340,8 @@ Status HaClient<Service>::Reconnect() {
     reconnect_idx_ = (reconnect_idx_ + 1) % addresses_.size();
 
     service_client_ = Service(address, options_);
+    VLOG(1) << strings::Substitute(
+            "Attempting to connect to $0", address.ToString());
     s = service_client_.Start();
     if (s.ok()) {
       VLOG(1) << strings::Substitute(

--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -1199,6 +1199,7 @@ TEST_F(ToolTest, TestModeHelp) {
         "set_comment.*Set the comment for a table",
         "set_extra_config.*Change a extra configuration value on a table",
         "set_limit.*Set the write limit for a table",
+        "set_replication_factor.*Change a table's replication factor",
         "statistics.*Get table statistics",
     };
     NO_FATALS(RunTestHelp(kCmd, kTableModeRegexes));
@@ -1225,6 +1226,7 @@ TEST_F(ToolTest, TestModeHelp) {
           "scan",
           "set_comment",
           "set_extra_config",
+          "set_replication_factor",
           "statistics",
         }));
   }
@@ -4541,6 +4543,85 @@ TEST_F(ToolTest, TestChangeTableLimitSupported) {
   statistics.reset(table_statistics);
   ASSERT_EQ(-1, statistics->live_row_count_limit());
   ASSERT_EQ(-1, statistics->on_disk_size_limit());
+}
+
+TEST_F(ToolTest, TestSetReplicationFactor) {
+  constexpr int kNumTservers = 4;
+  ExternalMiniClusterOptions opts;
+  opts.num_tablet_servers = kNumTservers;
+  NO_FATALS(StartExternalMiniCluster(std::move(opts)));
+  constexpr const char* const kTableName = "kudu.table.set.replication_factor";
+
+  KuduSchemaBuilder schema_builder;
+  schema_builder.AddColumn("key")
+      ->Type(client::KuduColumnSchema::INT32)
+      ->NotNull()
+      ->PrimaryKey();
+  schema_builder.AddColumn("value")
+      ->Type(client::KuduColumnSchema::INT32)
+      ->NotNull();
+  KuduSchema schema;
+  ASSERT_OK(schema_builder.Build(&schema));
+
+  // Create the table.
+  TestWorkload workload(cluster_.get());
+  workload.set_table_name(kTableName);
+  workload.set_schema(schema);
+  workload.set_num_replicas(1);
+  workload.Setup();
+
+  string master_addr = cluster_->master()->bound_rpc_addr().ToString();
+  shared_ptr<KuduClient> client;
+  ASSERT_OK(KuduClientBuilder()
+                .add_master_server_addr(master_addr)
+                .Build(&client));
+  shared_ptr<KuduTable> table;
+  ASSERT_OK(client->OpenTable(kTableName, &table));
+
+  ASSERT_EQ(1, table->num_replicas());
+
+  NO_FATALS(RunActionStdoutNone(Substitute("table set_replication_factor $0 $1 3",
+                                           master_addr, kTableName)));
+  ASSERT_OK(client->OpenTable(kTableName, &table));
+  ASSERT_EQ(3, table->num_replicas());
+
+  NO_FATALS(RunActionStdoutNone(Substitute("table set_replication_factor $0 $1 1",
+                                           master_addr, kTableName)));
+  ASSERT_OK(client->OpenTable(kTableName, &table));
+  ASSERT_EQ(1, table->num_replicas());
+
+  string stderr;
+  Status s = RunActionStderrString(
+      Substitute("table set_replication_factor $0 $1 3a",
+                 master_addr, kTableName), &stderr);
+  ASSERT_TRUE(s.IsRuntimeError());
+  ASSERT_STR_CONTAINS(stderr, "Unable to parse replication factor value: 3a.");
+
+  s = RunActionStderrString(
+      Substitute("table set_replication_factor $0 $1 0",
+                 master_addr, kTableName), &stderr);
+  ASSERT_TRUE(s.IsRuntimeError());
+  ASSERT_STR_CONTAINS(stderr, "Invalid replication factor: 0, it should be set higher than 0.");
+
+  s = RunActionStderrString(
+      Substitute("table set_replication_factor $0 $1 2",
+                 master_addr, kTableName), &stderr);
+  ASSERT_TRUE(s.IsRuntimeError());
+  ASSERT_STR_CONTAINS(stderr, "illegal replication factor 2: replication factor must be odd");
+
+  s = RunActionStderrString(
+      Substitute("table set_replication_factor $0 $1 5",
+                 master_addr, kTableName), &stderr);
+  ASSERT_TRUE(s.IsRuntimeError());
+  ASSERT_STR_CONTAINS(stderr, "not enough live tablet servers to alter a table with the"
+                              " requested replication factor 5; 4 tablet servers are alive");
+
+  s = RunActionStderrString(
+      Substitute("table set_replication_factor $0 $1 9",
+                 master_addr, kTableName), &stderr);
+  ASSERT_TRUE(s.IsRuntimeError());
+  ASSERT_STR_CONTAINS(stderr, "illegal replication factor 9: maximum allowed replication "
+                              "factor is 7 (controlled by --max_num_replicas)");
 }
 
 Status CreateLegacyHmsTable(HmsClient* client,

--- a/src/kudu/tools/table_scanner.h
+++ b/src/kudu/tools/table_scanner.h
@@ -61,6 +61,11 @@ class TableScanner {
   // Set replica selection for scan operations.
   Status SetReplicaSelection(const std::string& selection);
 
+  // Set the size for scan result batch size, in bytes. A negative value has
+  // the semantics of relying on the server-side default: see the
+  // --scanner_default_batch_size_bytes flag.
+  void SetScanBatchSize(int32_t scan_batch_size);
+
   Status StartScan();
   Status StartCopy();
 
@@ -101,6 +106,7 @@ class TableScanner {
   client::KuduClient::ReplicaSelection replica_selection_;
   boost::optional<client::sp::shared_ptr<client::KuduClient>> dst_client_;
   boost::optional<std::string> dst_table_name_;
+  int32_t scan_batch_size_;
   std::unique_ptr<ThreadPool> thread_pool_;
 
   // Protects output to 'out_' so that rows don't get interleaved.

--- a/src/kudu/tools/tool_action_perf.cc
+++ b/src/kudu/tools/tool_action_perf.cc
@@ -382,6 +382,7 @@ DEFINE_bool(txn_rollback, false,
 
 DECLARE_bool(show_values);
 DECLARE_int32(num_threads);
+DECLARE_int32(scan_batch_size);
 DECLARE_string(replica_selection);
 DECLARE_string(table_name);
 
@@ -926,6 +927,7 @@ Status TableScan(const RunnerContext& context) {
   FLAGS_show_values = false;
   TableScanner scanner(client, table_name);
   scanner.SetOutput(&cout);
+  scanner.SetScanBatchSize(FLAGS_scan_batch_size);
   const auto& replica_selection_str = FLAGS_replica_selection;
   if (!replica_selection_str.empty()) {
     RETURN_NOT_OK(scanner.SetReplicaSelection(replica_selection_str));
@@ -1063,6 +1065,7 @@ unique_ptr<Mode> BuildPerfMode() {
       .AddOptionalParameter("columns")
       .AddOptionalParameter("row_count_only")
       .AddOptionalParameter("report_scanner_stats")
+      .AddOptionalParameter("scan_batch_size")
       .AddOptionalParameter("fill_cache")
       .AddOptionalParameter("num_threads")
       .AddOptionalParameter("predicates")

--- a/src/kudu/tools/tool_action_table.cc
+++ b/src/kudu/tools/tool_action_table.cc
@@ -114,6 +114,11 @@ DEFINE_string(lower_bound_type, "INCLUSIVE_BOUND",
 DEFINE_string(upper_bound_type, "EXCLUSIVE_BOUND",
               "The type of the upper bound, either inclusive or exclusive. "
               "Defaults to exclusive. This flag is case-insensitive.");
+DEFINE_int32(scan_batch_size, -1,
+             "The size for scan results batches, in bytes. A negative value "
+             "means the server-side default is used, where the server-side "
+             "default is controlled by the tablet server's "
+             "--scanner_default_batch_size_bytes flag.");
 
 DECLARE_bool(row_count_only);
 DECLARE_bool(show_scanner_stats);
@@ -490,6 +495,7 @@ Status ScanTable(const RunnerContext &context) {
   }
   TableScanner scanner(client, table_name);
   scanner.SetOutput(&cout);
+  scanner.SetScanBatchSize(FLAGS_scan_batch_size);
   const auto& replica_selection_str = FLAGS_replica_selection;
   if (!replica_selection_str.empty()) {
     RETURN_NOT_OK(scanner.SetReplicaSelection(replica_selection_str));
@@ -1323,6 +1329,7 @@ unique_ptr<Mode> BuildTableMode() {
       .AddOptionalParameter("columns")
       .AddOptionalParameter("row_count_only")
       .AddOptionalParameter("report_scanner_stats")
+      .AddOptionalParameter("scan_batch_size")
       .AddOptionalParameter("fill_cache")
       .AddOptionalParameter("num_threads")
       .AddOptionalParameter("predicates")


### PR DESCRIPTION
In some cases we want to increase a table's replciation factor. For
example, convert a test table to production table, fix a table's RF
which is created by a buggy program.

This patch add a function to alter table's replication factor, supported
in CLI tool, and also add some unit tests.

Change-Id: I3aa2d5b12c508ba761fa9410ad1a465cf31fb7d7