### PR TITLE
[fs] Add limit for log block container metadata

### DIFF
--- a/src/kudu/fs/log_block_manager.cc
+++ b/src/kudu/fs/log_block_manager.cc
@@ -80,6 +80,13 @@ DEFINE_uint64(log_container_max_size, 10LU * 1024 * 1024 * 1024,
               "Maximum size (soft) of a log container");
 TAG_FLAG(log_container_max_size, advanced);
 
+DEFINE_uint64(log_container_metadata_max_size, 0,
+              "Maximum size (soft) of a log container's metadata. Use 0 for "
+              "no limit.");
+TAG_FLAG(log_container_metadata_max_size, advanced);
+TAG_FLAG(log_container_metadata_max_size, experimental);
+TAG_FLAG(log_container_metadata_max_size, runtime);
+
 DEFINE_int64(log_container_max_blocks, -1,
              "Maximum number of blocks (soft) of a log container. Use 0 for "
              "no limit. Use -1 for no limit except in the case of a kernel "
@@ -534,7 +541,9 @@ class LogBlockContainer: public RefCountedThreadSafe<LogBlockContainer> {
   int32_t blocks_being_written() const { return blocks_being_written_.Load(); }
   bool full() const {
     return next_block_offset() >= FLAGS_log_container_max_size ||
-        (max_num_blocks_ && (total_blocks() >= max_num_blocks_));
+        (max_num_blocks_ && (total_blocks() >= max_num_blocks_)) ||
+        (FLAGS_log_container_metadata_max_size > 0 &&
+         (metadata_file_->Offset() >= FLAGS_log_container_metadata_max_size));
   }
   bool dead() const { return dead_.Load(); }
   const LogBlockManagerMetrics* metrics() const { return metrics_; }

--- a/src/kudu/util/pb_util.cc
+++ b/src/kudu/util/pb_util.cc
@@ -772,6 +772,11 @@ Status WritablePBContainerFile::Sync() {
   return Status::OK();
 }
 
+uint64_t WritablePBContainerFile::Offset() const {
+  std::lock_guard<Mutex> l(offset_lock_);
+  return offset_;
+}
+
 Status WritablePBContainerFile::Close() {
   if (state_ != FileState::CLOSED) {
     state_ = FileState::CLOSED;

--- a/src/kudu/util/pb_util.h
+++ b/src/kudu/util/pb_util.h
@@ -315,6 +315,9 @@ class WritablePBContainerFile {
   // only needed in the former case.
   Status Sync();
 
+  // Get current offset of underlying file.
+  uint64_t Offset() const;
+
   // Closes the container.
   //
   // Not thread-safe.
@@ -350,7 +353,7 @@ class WritablePBContainerFile {
   FileState state_;
 
   // Protects offset_.
-  Mutex offset_lock_;
+  mutable Mutex offset_lock_;
 
   // Current write offset into the file.
   uint64_t offset_;


### PR DESCRIPTION
In some cases, log block container's data file is very small
after punching hole, while metadata file is very large cause it
contains many CREATE-DELETE pairs. This situation will cause
disk space wasting because it's hard to reach a container size
limit.
This patch add a limit to log block container's metadata to
avoid wasting too much disk space.

Change-Id: I12513abf2e45f7bdf091142c31f50d650b6f0cfc