### PR TITLE
[tools] Add role filed when list remote replicas

### DIFF
--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -3395,12 +3395,14 @@ TEST_F(ToolTest, TestRemoteReplicaList) {
     NO_FATALS(RunActionStdoutString(
         Substitute("remote_replica list $0", ts_addr), &stdout));
 
-    // Some fields like state or estimated on disk size may vary. Just check a
+    // Some fields like estimated on disk size may vary. Just check a
     // few whose values we should know exactly.
-    ASSERT_STR_CONTAINS(stdout,
-                        Substitute("Tablet id: $0", tablet_status.tablet_id()));
-    ASSERT_STR_CONTAINS(stdout,
-                        Substitute("Table name: $0", workload.table_name()));
+    ASSERT_STR_CONTAINS(stdout, Substitute("Tablet id: $0", tablet_status.tablet_id()));
+    ASSERT_STR_MATCHES(stdout, Substitute("State: (INITIALIZED|BOOTSTRAPPING|RUNNING)"));
+    // Check all possible roles regardless of the reality.
+    ASSERT_STR_MATCHES(stdout,
+                       Substitute("Role: (UNKNOWN_ROLE|FOLLOWER|LEADER|LEARNER|NON_PARTICIPANT)"));
+    ASSERT_STR_CONTAINS(stdout, Substitute("Table name: $0", workload.table_name()));
     ASSERT_STR_CONTAINS(stdout, "key INT32 NOT NULL");
     ASSERT_STR_CONTAINS(stdout, "Last status: No bootstrap required, opened a new log");
     ASSERT_STR_CONTAINS(stdout, "Data state: TABLET_DATA_READY");

--- a/src/kudu/tools/tool_action_remote_replica.cc
+++ b/src/kudu/tools/tool_action_remote_replica.cc
@@ -318,6 +318,9 @@ Status ListReplicas(const RunnerContext& context) {
     cout << "Tablet id: " << rs.tablet_id() << endl;
     cout << "State: " << state << endl;
     cout << "Last status: " << rs.last_status() << endl;
+    if (r.has_role()) {
+      cout << "Role: " << RaftPeerPB::Role_Name(r.role()) << endl;
+    }
     cout << "Table name: " << rs.table_name() << endl;
     cout << "Partition: "
          << partition_schema.PartitionDebugString(partition, schema) << endl;

--- a/src/kudu/tserver/tserver.proto
+++ b/src/kudu/tserver/tserver.proto
@@ -22,6 +22,7 @@ option java_package = "org.apache.kudu.tserver";
 import "kudu/common/common.proto";
 import "kudu/common/row_operations.proto";
 import "kudu/common/wire_protocol.proto";
+import "kudu/consensus/metadata.proto";
 import "kudu/security/token.proto";
 import "kudu/tablet/tablet.proto";
 import "kudu/util/pb_util.proto";
@@ -206,6 +207,7 @@ message ListTabletsResponsePB {
     optional SchemaPB schema = 2;
     optional PartitionSchemaPB partition_schema = 3;
     optional uint32 schema_version = 4;
+    optional consensus.RaftPeerPB.Role role = 5;
   }
 
   repeated StatusAndSchemaPB status_and_schema = 2;


### PR DESCRIPTION
Add a raft role filed for output of 'kudu remote_replica list',
it's useful when you want to, for example, grep only LEADER replicas.

Change-Id: Ie38d20d129b18f3a170ec5b0db5a2caf7c0d80ef