### PR TITLE
[metrics] Add table level metrics column_count and schema_version on …

### DIFF
--- a/src/kudu/master/catalog_manager.h
+++ b/src/kudu/master/catalog_manager.h
@@ -360,9 +360,13 @@ class TableInfo : public RefCountedThreadSafe<TableInfo> {
   void UnregisterMetrics();
 
   // Update stats belonging to 'tablet_id' in the table's metrics.
-  void UpdateMetrics(const std::string& tablet_id,
-                     const tablet::ReportedTabletStatsPB& old_stats,
-                     const tablet::ReportedTabletStatsPB& new_stats);
+  void UpdateStatsMetrics(const std::string& tablet_id,
+                          const tablet::ReportedTabletStatsPB& old_stats,
+                          const tablet::ReportedTabletStatsPB& new_stats);
+
+  // Update table's schema related metrics, for exapmle, schema version,
+  // column count, and etc.
+  void UpdateSchemaMetrics();
 
   // Invalidate stats belonging to 'tablet_id' in the table's metrics.
   void InvalidateMetrics(const std::string& tablet_id);

--- a/src/kudu/master/table_metrics.cc
+++ b/src/kudu/master/table_metrics.cc
@@ -36,12 +36,22 @@ METRIC_DEFINE_gauge_uint64(table, live_row_count, "Table Live Row count",
     "Pre-replication aggregated number of live rows in this table. "
     "Only accurate if all tablets in the table support live row counting.",
     kudu::MetricLevel::kInfo);
+METRIC_DEFINE_gauge_uint32(table, column_count, "Table Column count",
+    kudu::MetricUnit::kUnits,
+    "The column count in the table's latest schema.",
+    kudu::MetricLevel::kInfo);
+METRIC_DEFINE_gauge_uint32(table, schema_version, "Table Schema Version",
+    kudu::MetricUnit::kUnits,
+    "The table's schema version.",
+    kudu::MetricLevel::kInfo);
 
 #define GINIT(x) x(METRIC_##x.Instantiate(entity, 0))
 #define HIDEINIT(x, v) x(METRIC_##x.InstantiateHidden(entity, v))
 TableMetrics::TableMetrics(const scoped_refptr<MetricEntity>& entity)
   : GINIT(on_disk_size),
     GINIT(live_row_count),
+    GINIT(column_count),
+    GINIT(schema_version),
     HIDEINIT(merged_entities_count_of_table, 1) {
 }
 #undef GINIT

--- a/src/kudu/master/table_metrics.h
+++ b/src/kudu/master/table_metrics.h
@@ -49,6 +49,8 @@ struct TableMetrics {
 
   scoped_refptr<AtomicGauge<uint64_t>> on_disk_size;
   scoped_refptr<AtomicGauge<uint64_t>> live_row_count;
+  scoped_refptr<AtomicGauge<uint32_t>> column_count;
+  scoped_refptr<AtomicGauge<uint32_t>> schema_version;
   scoped_refptr<AtomicGauge<size_t>> merged_entities_count_of_table;
 
   void AddTabletNoOnDiskSize(const std::string& tablet_id);


### PR DESCRIPTION
…master

This patch adds some table level metrics on master.
- column_count: The column count in the table's latest schema. Since too
  many column count will lead to bad performance and space
  amplification, we can add some monitor alerts based on this
  metric after this.
- schema_version: The table's schema version. Too many or too
  frequently schema changes is also a metric worth to be monitored.

Change-Id: Ia0671cfb0758d53e950a4e35a968dae15f82d18e