### PR TITLE
Use GTEST_SKIP() to skip tests

### DIFF
--- a/src/kudu/cfile/cfile-test.cc
+++ b/src/kudu/cfile/cfile-test.cc
@@ -1075,7 +1075,9 @@ TEST_P(TestCFileBothCacheMemoryTypes, TestCacheKeysAreStable) {
 
 // Inject failures in nvm allocation and ensure that we can still read a file.
 TEST_P(TestCFileBothCacheMemoryTypes, TestNvmAllocationFailure) {
-  if (GetParam() != Cache::MemoryType::NVM) return;
+  if (GetParam() != Cache::MemoryType::NVM) {
+    GTEST_SKIP();
+  }
   RETURN_IF_NO_NVM_CACHE(GetParam());
 
   FLAGS_nvm_cache_simulate_allocation_failure = true;

--- a/src/kudu/fs/block_manager-test.cc
+++ b/src/kudu/fs/block_manager-test.cc
@@ -97,8 +97,8 @@ METRIC_DECLARE_gauge_uint64(data_dirs_full);
 #define RETURN_NOT_LOG_BLOCK_MANAGER() \
   do { \
     if (FLAGS_block_manager != "log") { \
-      LOG(INFO) << "This platform does not use the log block manager by default. Skipping test."; \
-      return; \
+      GTEST_SKIP() << "This platform does not use the log block manager by default. " \
+                      "Skipping test."; \
     } \
   } while (false)
 

--- a/src/kudu/fs/fs_manager-test.cc
+++ b/src/kudu/fs/fs_manager-test.cc
@@ -932,8 +932,7 @@ TEST_P(FsManagerTestBase, TestOpenFailsWhenMissingImportantDir) {
 
 TEST_P(FsManagerTestBase, TestAddRemoveDataDirs) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, file block manager not supported";
-    return;
+    GTEST_SKIP() << "Skipping test, file block manager not supported";
   }
 
   // Try to open with a new data dir in the list to be opened; Kudu should
@@ -974,8 +973,7 @@ TEST_P(FsManagerTestBase, TestAddRemoveDataDirs) {
 
 TEST_P(FsManagerTestBase, TestEIOWhileChangingDirs) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "The file block manager doesn't support updating directories";
-    return;
+    GTEST_SKIP() << "The file block manager doesn't support updating directories";
   }
   const string kTestPathBase = GetTestPath("testpath");
   const int kMaxDirs = 10;
@@ -1009,8 +1007,7 @@ TEST_P(FsManagerTestBase, TestEIOWhileChangingDirs) {
 // happens, we should ensure that the our failures to update get rolled back.
 TEST_P(FsManagerTestBase, TestEIOWhileRunningUpdateDirsTool) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "The file block manager doesn't support updating directories";
-    return;
+    GTEST_SKIP() << "The file block manager doesn't support updating directories";
   }
   const string kTestPathBase = GetTestPath("testpath");
   // Helper to get a new root.
@@ -1100,8 +1097,7 @@ TEST_P(FsManagerTestBase, TestEIOWhileRunningUpdateDirsTool) {
 
 TEST_P(FsManagerTestBase, TestReAddRemovedDataDir) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, file block manager not supported";
-    return;
+    GTEST_SKIP() << "Skipping test, file block manager not supported";
   }
 
   // Add a new data directory, remove it, and add it back.
@@ -1137,8 +1133,7 @@ TEST_P(FsManagerTestBase, TestReAddRemovedDataDir) {
 
 TEST_P(FsManagerTestBase, TestCannotRemoveDataDirServingAsMetadataDir) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, file block manager not supported";
-    return;
+    GTEST_SKIP() << "Skipping test, file block manager not supported";
   }
 
   // Create a new fs layout with a metadata root explicitly set to the first
@@ -1173,8 +1168,7 @@ TEST_P(FsManagerTestBase, TestCannotRemoveDataDirServingAsMetadataDir) {
 
 TEST_P(FsManagerTestBase, TestAddRemoveSpeculative) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, file block manager not supported";
-    return;
+    GTEST_SKIP() << "Skipping test, file block manager not supported";
   }
 
   // Add a second data directory.
@@ -1238,8 +1232,7 @@ TEST_P(FsManagerTestBase, TestAddRemoveDataDirsFuzz) {
   const int kNumAttempts = AllowSlowTests() ? 1000 : 100;
 
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, file block manager not supported";
-    return;
+    GTEST_SKIP() << "Skipping test, file block manager not supported";
   }
 
   Random rng_(SeedRandom());

--- a/src/kudu/integration-tests/ts_recovery-itest.cc
+++ b/src/kudu/integration-tests/ts_recovery-itest.cc
@@ -237,9 +237,8 @@ TEST_P(TsRecoveryITest, TestTabletRecoveryAfterSegmentDelete) {
 // that are referenced by a tablet will not be reused.
 TEST_P(TsRecoveryITest, TestNoBlockIDReuseIfMissingBlocks) {
   if (GetParam() != "log") {
-    LOG(INFO) << "Missing blocks is currently only supported by the log "
-                 "block manager. Exiting early!";
-    return;
+    GTEST_SKIP() << "Missing blocks is currently only supported by the log "
+                    "block manager. Exiting early!";
   }
   // Set up a basic server that flushes often so we create blocks quickly.
   NO_FATALS(StartClusterOneTs({

--- a/src/kudu/rpc/rpc-test.cc
+++ b/src/kudu/rpc/rpc-test.cc
@@ -65,6 +65,7 @@
 #include "kudu/util/monotime.h"
 #include "kudu/util/net/sockaddr.h"
 #include "kudu/util/net/socket.h"
+#include "kudu/util/net/socket_info.pb.h"
 #include "kudu/util/random.h"
 #include "kudu/util/random_util.h"
 #include "kudu/util/scoped_cleanup.h"
@@ -242,7 +243,9 @@ TEST_P(TestRpc, TestCall) {
 // Test for KUDU-2091 and KUDU-2220.
 TEST_P(TestRpc, TestCallWithChainCertAndChainCA) {
   // We're only interested in running this test with TLS enabled.
-  if (!enable_ssl()) return;
+  if (!enable_ssl()) {
+    GTEST_SKIP();
+  }
 
   string rpc_certificate_file;
   string rpc_private_key_file;
@@ -273,7 +276,9 @@ TEST_P(TestRpc, TestCallWithChainCertAndChainCA) {
 // Test for KUDU-2041.
 TEST_P(TestRpc, TestCallWithChainCertAndRootCA) {
   // We're only interested in running this test with TLS enabled.
-  if (!enable_ssl()) return;
+  if (!enable_ssl()) {
+    GTEST_SKIP();
+  }
 
   string rpc_certificate_file;
   string rpc_private_key_file;
@@ -305,7 +310,9 @@ TEST_P(TestRpc, TestCallWithChainCertAndRootCA) {
 // private key.
 TEST_P(TestRpc, TestCallWithPasswordProtectedKey) {
   // We're only interested in running this test with TLS enabled.
-  if (!enable_ssl()) return;
+  if (!enable_ssl()) {
+    GTEST_SKIP();
+  }
 
   string rpc_certificate_file;
   string rpc_private_key_file;
@@ -341,7 +348,9 @@ TEST_P(TestRpc, TestCallWithPasswordProtectedKey) {
 // the wrong password for that private key, causes a server startup failure.
 TEST_P(TestRpc, TestCallWithBadPasswordProtectedKey) {
   // We're only interested in running this test with TLS enabled.
-  if (!enable_ssl()) return;
+  if (!enable_ssl()) {
+    GTEST_SKIP();
+  }
 
   string rpc_certificate_file;
   string rpc_private_key_file;
@@ -437,8 +446,7 @@ TEST_P(TestRpc, TestHighFDs) {
   const int kNumFakeFiles = 3500;
   const int kMinUlimit = kNumFakeFiles + 100;
   if (env_->GetResourceLimit(Env::ResourceLimitType::OPEN_FILES_PER_PROCESS) < kMinUlimit) {
-    LOG(INFO) << "Test skipped: must increase ulimit -n to at least " << kMinUlimit;
-    return;
+    GTEST_SKIP() << "Test skipped: must increase ulimit -n to at least " << kMinUlimit;
   }
 
   // Open a bunch of fds just to increase our fd count.

--- a/src/kudu/server/webserver-test.cc
+++ b/src/kudu/server/webserver-test.cc
@@ -178,7 +178,7 @@ class PasswdWebserverTest : public WebserverTest {
 // the request as the .htpasswd is presented to webserver.
 TEST_F(PasswdWebserverTest, TestPasswdMissing) {
   if (fips_mode) {
-    return;
+    GTEST_SKIP();
   }
   Status status = curl_.FetchURL(url_, &buf_);
   ASSERT_EQ("Remote error: HTTP 401", status.ToString());
@@ -186,7 +186,7 @@ TEST_F(PasswdWebserverTest, TestPasswdMissing) {
 
 TEST_F(PasswdWebserverTest, TestPasswdPresent) {
   if (fips_mode) {
-    return;
+    GTEST_SKIP();
   }
   ASSERT_OK(curl_.set_auth(CurlAuthType::DIGEST, security::kTestAuthUsername,
                            security::kTestAuthPassword));
@@ -195,7 +195,7 @@ TEST_F(PasswdWebserverTest, TestPasswdPresent) {
 
 TEST_F(PasswdWebserverTest, TestCrashInFIPSMode) {
   if (!fips_mode) {
-    return;
+    GTEST_SKIP();
   }
 
   Status s = server_->Start();

--- a/src/kudu/tablet/compaction-test.cc
+++ b/src/kudu/tablet/compaction-test.cc
@@ -1387,8 +1387,7 @@ TEST_F(TestCompaction, TestCompactionFreesDiskSpace) {
 // would result in orphaning near-empty cfile blocks on the disk.
 TEST_F(TestCompaction, TestEmptyFlushDoesntLeakBlocks) {
   if (FLAGS_block_manager != "log") {
-    LOG(WARNING) << "Test requires the log block manager";
-    GTEST_SKIP();
+    GTEST_SKIP() << "Test requires the log block manager";
   }
 
   // Fetch the metric for the number of on-disk blocks, so we can later verify

--- a/src/kudu/tablet/tablet-decoder-eval-test.cc
+++ b/src/kudu/tablet/tablet-decoder-eval-test.cc
@@ -91,8 +91,7 @@ public:
 
   void ScanAndFilter(size_t cardinality, size_t lower, size_t upper, int null_upper) {
     if (GetParam() == LARGE && !AllowSlowTests()) {
-      LOG(INFO) << "Skipped large test case";
-      return;
+      GTEST_SKIP() << "Skipped large test case";
     }
     size_t nrows = static_cast<size_t>(GetParam());
     // The correctness check of this test requires that the int and string
@@ -220,8 +219,7 @@ public:
 
   void TestMultipleColumnPredicates(size_t cardinality, size_t lower, size_t upper) {
     if (GetParam() == LARGE && !AllowSlowTests()) {
-      LOG(INFO) << "Skipped large test case";
-      return;
+      GTEST_SKIP() << "Skipped large test case";
     }
     size_t nrows = static_cast<size_t>(GetParam());
     size_t strlen = std::max({static_cast<size_t>(FLAGS_decoder_eval_test_strlen),

--- a/src/kudu/tools/ksck_remote-test.cc
+++ b/src/kudu/tools/ksck_remote-test.cc
@@ -517,10 +517,9 @@ TEST_F(RemoteKsckTest, TestChecksumSnapshotLastingLongerThanAHM) {
   // happen during the wait to start the checksum, for each tablet. It's likely
   // this sometimes won't happen in builds that are slower, so we'll just
   // disable the test for those builds.
-  #if defined(THREAD_SANITIZER) || defined(ADDRESS_SANITIZER)
-    LOG(WARNING) << "test is skipped in TSAN and ASAN builds";
-    return;
-  #endif
+#if defined(THREAD_SANITIZER) || defined(ADDRESS_SANITIZER)
+  GTEST_SKIP() << "test is skipped in TSAN and ASAN builds";
+#endif
 
   // Write something so we have rows to checksum, and because we need a valid
   // timestamp from the client to use for a checksum scan.

--- a/src/kudu/tools/kudu-tool-test.cc
+++ b/src/kudu/tools/kudu-tool-test.cc
@@ -8083,8 +8083,7 @@ static void CreateTableWithFlushedData(const string& table_name,
 // data directories, which is not supported.
 TEST_F(ToolTest, TestFsSwappingDirectoriesFailsGracefully) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, only log block manager is supported";
-    return;
+    GTEST_SKIP() << "Skipping test, only log block manager is supported";
   }
 
   // Configure the server to share the data root and wal root.
@@ -8270,8 +8269,7 @@ TEST_F(ToolTest, TestStartEndMaintenanceMode) {
 
 TEST_F(ToolTest, TestFsRemoveDataDirWithTombstone) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, only log block manager is supported";
-    return;
+    GTEST_SKIP() << "Skipping test, only log block manager is supported";
   }
 
   // Start a cluster whose tserver has multiple data directories and create a
@@ -8309,8 +8307,7 @@ TEST_F(ToolTest, TestFsAddRemoveDataDirEndToEnd) {
   const string kTableBar = "bar";
 
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test, only log block manager is supported";
-    return;
+    GTEST_SKIP() << "Skipping test, only log block manager is supported";
   }
 
   // Disable the available space heuristic as it can interfere with the desired

--- a/src/kudu/tserver/tablet_server-test.cc
+++ b/src/kudu/tserver/tablet_server-test.cc
@@ -1152,8 +1152,8 @@ TEST_F(TabletServerTest, TestEIODuringDelete) {
 // across the removed directories.
 TEST_F(TabletServerTest, TestAddRemoveDirectory) {
   if (FLAGS_block_manager == "file") {
-    LOG(INFO) << "Skipping test since the file block manager does not support updating directories";
-    return;
+    GTEST_SKIP() << "Skipping test since the file block manager does not support "
+                    "updating directories";
   }
   // Start with multiple data dirs so the dirs are suffixed with numbers, and
   // so when we remove a data dirs, we'll be using the same set of dirs.

--- a/src/kudu/util/env-test.cc
+++ b/src/kudu/util/env-test.cc
@@ -246,8 +246,7 @@ bool TestEnv::fallocate_punch_hole_supported_ = false;
 
 TEST_F(TestEnv, TestPreallocate) {
   if (!fallocate_supported_) {
-    LOG(INFO) << "fallocate not supported, skipping test";
-    return;
+    GTEST_SKIP() << "fallocate not supported, skipping test";
   }
   LOG(INFO) << "Testing PreAllocate()";
   string test_path = GetTestPath("test_env_wf");
@@ -285,8 +284,7 @@ TEST_F(TestEnv, TestPreallocate) {
 // be smaller than the mmapped regions size).
 TEST_F(TestEnv, TestConsecutivePreallocate) {
   if (!fallocate_supported_) {
-    LOG(INFO) << "fallocate not supported, skipping test";
-    return;
+    GTEST_SKIP() << "fallocate not supported, skipping test";
   }
   LOG(INFO) << "Testing consecutive PreAllocate()";
   string test_path = GetTestPath("test_env_wf");
@@ -345,8 +343,7 @@ TEST_F(TestEnv, TestConsecutivePreallocate) {
 
 TEST_F(TestEnv, TestHolePunch) {
   if (!fallocate_punch_hole_supported_) {
-    LOG(INFO) << "hole punching not supported, skipping test";
-    return;
+    GTEST_SKIP() << "hole punching not supported, skipping test";
   }
   string test_path = GetTestPath("test_env_wf");
   unique_ptr<RWFile> file;
@@ -382,8 +379,7 @@ TEST_F(TestEnv, TestHolePunchBenchmark) {
   const int kHoleSize = 10 * kOneMb;
   const int kNumRuns = 1000;
   if (!fallocate_punch_hole_supported_) {
-    LOG(INFO) << "hole punching not supported, skipping test";
-    return;
+    GTEST_SKIP() << "hole punching not supported, skipping test";
   }
   Random r(SeedRandom());
 

--- a/src/kudu/util/interval_tree-test.cc
+++ b/src/kudu/util/interval_tree-test.cc
@@ -320,8 +320,7 @@ TEST_F(TestIntervalTree, TestEmpty) {
 
 TEST_F(TestIntervalTree, TestBigO) {
 #ifndef NDEBUG
-  LOG(WARNING) << "big-O results are not valid if DCHECK is enabled";
-  return;
+  GTEST_SKIP() << "big-O results are not valid if DCHECK is enabled";
 #endif
   SeedRandom();
 

--- a/src/kudu/util/logging-test.cc
+++ b/src/kudu/util/logging-test.cc
@@ -348,8 +348,7 @@ TEST(LoggingTest, TestLogTiming) {
 // in hot code paths.
 TEST(LoggingTest, TestVlogDoesNotEvaluateMessage) {
   if (VLOG_IS_ON(1)) {
-    LOG(INFO) << "Test skipped: verbose level is at least 1";
-    return;
+    GTEST_SKIP() << "Test skipped: verbose level is at least 1";
   }
 
   int numVlogs = 0;

--- a/src/kudu/util/minidump-test.cc
+++ b/src/kudu/util/minidump-test.cc
@@ -116,14 +116,14 @@ TEST_P(MinidumpSignalDeathTest, TestHaveMinidumpAndStackTrace) {
 #if defined(ADDRESS_SANITIZER)
   // ASAN appears to catch SIGBUS, SIGSEGV, and SIGFPE and the process is not killed.
   if (signal == SIGBUS || signal == SIGSEGV || signal == SIGFPE) {
-    return;
+    GTEST_SKIP();
   }
 #endif
 
 #if defined(THREAD_SANITIZER)
   // TSAN appears to catch SIGTERM and the process is not killed.
   if (signal == SIGTERM) {
-    return;
+    GTEST_SKIP();
   }
 #endif
 

--- a/src/kudu/util/test_util.h
+++ b/src/kudu/util/test_util.h
@@ -34,8 +34,7 @@
 
 #define SKIP_IF_SLOW_NOT_ALLOWED() do { \
   if (!AllowSlowTests()) { \
-    LOG(WARNING) << "test is skipped; set KUDU_ALLOW_SLOW_TESTS=1 to run"; \
-    GTEST_SKIP(); \
+    GTEST_SKIP() << "test is skipped; set KUDU_ALLOW_SLOW_TESTS=1 to run"; \
   } \
 } while (0)
 


### PR DESCRIPTION
GTEST_SKIP() is better than manually logging and return, the former is able to print hint messages and the skipped tests in result.

Change-Id: Id3c39255e97cfc67a8cb8d01f8aefa74d570e786