### PR TITLE
KUDU-3580 the crash bug when run binaries on older CPU machines

### DIFF
--- a/thirdparty/build-definitions.sh
+++ b/thirdparty/build-definitions.sh
@@ -1198,6 +1198,7 @@ build_rocksdb() {
     CXXFLAGS="$EXTRA_CXXFLAGS -fPIC" \
     cmake \
     -DROCKSDB_BUILD_SHARED=ON \
+    -DPORTABLE=$PORTABLE \
     -DWITH_SNAPPY=ON \
     -Dsnappy_ROOT_DIR=$PREFIX \
     -DUSE_RTTI=ON \

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -35,6 +35,9 @@
 #   * EXTRA_LIBS - additional libraries to link.
 #   * EXTRA_MAKEFLAGS - additional flags passed to make.
 #   * PARALLEL - parallelism to use when compiling (defaults to number of cores).
+#   * PORTABLE - whether to build portable libraries, otherwise build native libraries. Portable
+#                libraries may cause a slight performance degradation, it's recommend to disable
+#                portable option if there is no port requirements. (defaults to ON).
 
 set -ex
 
@@ -203,6 +206,9 @@ else
   echo Unsupported platform $OSTYPE
   exit 1
 fi
+
+### Build portable libraries by default.
+PORTABLE=${PORTABLE:-"ON"}
 
 ### Detect and enable 'ninja' instead of 'make' for faster builds.
 if which ninja-build > /dev/null ; then


### PR DESCRIPTION
After Kudu linking rocksdb, the Kudu binaries may
crash with error "Illegal instruction" when running on the machines which don't support newer CPU
instruction (e.g. AVX512) but were built on the
machine which supports.

This patch enable the WITH_SNAPPY option when build librocksdb to fix the issue.

Change-Id: Id30ae995c41a592fccbdb822bc1f457c5e6878ac