### PR TITLE
KUDU-3606 [tools] Show column ids when using 'kudu table describe'

### DIFF
--- a/src/kudu/client/schema.cc
+++ b/src/kudu/client/schema.cc
@@ -50,6 +50,9 @@ DEFINE_bool(show_attributes, false,
 DEFINE_bool(show_column_comment, false,
             "Whether to show column comment.");
 
+DEFINE_bool(show_column_id, false,
+            "Whether to show column id.");
+
 MAKE_ENUM_LIMITS(kudu::client::KuduColumnStorageAttributes::EncodingType,
                  kudu::client::KuduColumnStorageAttributes::AUTO_ENCODING,
                  kudu::client::KuduColumnStorageAttributes::RLE);
@@ -1045,6 +1048,9 @@ string KuduSchema::ToString() const {
   }
   if (FLAGS_show_column_comment) {
     mode |= Schema::ToStringMode::WITH_COLUMN_COMMENTS;
+  }
+  if (FLAGS_show_column_id) {
+    mode |= Schema::ToStringMode::WITH_COLUMN_IDS;
   }
   return schema_->ToString(mode);
 }

--- a/src/kudu/tools/tool_action_table.cc
+++ b/src/kudu/tools/tool_action_table.cc
@@ -1922,8 +1922,9 @@ unique_ptr<Mode> BuildTableMode() {
       .Description("Describe a table")
       .AddRequiredParameter({ kTableNameArg, "Name of the table to describe" })
       .AddOptionalParameter("show_attributes")
-      .AddOptionalParameter("show_column_comment")
       .AddOptionalParameter("show_avro_format_schema")
+      .AddOptionalParameter("show_column_comment")
+      .AddOptionalParameter("show_column_id")
       .Build();
 
   unique_ptr<Action> list_tables =


### PR DESCRIPTION
Column id is an internal concept, this patch
adds a new flag --show_column_id to indicate
whether to show it when using 'kudu table describe'.

It's helpful to compare whether two tables'
schema are competely the same with considering
the internal column id as well.

Change-Id: Ib9b28bd8f879bb6cace1683bc366c72772caebdc